### PR TITLE
fix(analyser): restrict NEA0006 to string .Length receivers

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfLengthAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfLengthAnalyzer.cs
@@ -42,6 +42,15 @@ public sealed class ThrowIfLengthAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        var receiverType = context
+            .SemanticModel.GetTypeInfo(comparison.Value.ValueExpression, context.CancellationToken)
+            .Type;
+
+        if (receiverType?.SpecialType != SpecialType.System_String)
+        {
+            return;
+        }
+
         if (
             !SyntaxHelpers.TryGetThrownException(
                 ifStatement,

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfLengthAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfLengthAnalyzerTests.cs
@@ -71,4 +71,51 @@ public sealed class ThrowIfLengthAnalyzerTests
 
         _ = await Assert.That(diagnostics).IsEmpty();
     }
+
+    [Test]
+    [Arguments("int[] argument", "argument.Length > 100")]
+    [Arguments("System.Span<char> argument", "argument.Length > 100")]
+    public async Task Analyze_WhenLengthReceiverIsNotString_DoesNotReportDiagnostic(string parameter, string condition)
+    {
+        var source = $$"""
+            using System;
+
+            class C
+            {
+                void M({{parameter}})
+                {
+                    if ({{condition}}) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfLengthAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenLengthReceiverIsUserDefinedTypeWithLengthProperty_DoesNotReportDiagnostic()
+    {
+        var source = """
+            using System;
+
+            class Buffer
+            {
+                public int Length { get; }
+            }
+
+            class C
+            {
+                void M(Buffer argument)
+                {
+                    if (argument.Length > 100) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfLengthAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
 }


### PR DESCRIPTION
## Defect

`ThrowIfLengthAnalyzer` (rule NEA0006) recognized a `.Length` comparison-then-throw pattern by matching the member access's identifier text (`Name.Identifier.Text: "Length"`) only. It never resolved the type of the expression the `.Length` was accessed on, even though the offered code fix rewrites the site to a call on `ArgumentException.ThrowIfLength*(string?)`, which only accepts `string`.

As a result, the analyzer fired — and the code fix offered a rewrite — for any `.Length` receiver, including the single most common one in C#: `int[]`.

### Before

```csharp
void M(int[] a)
{
    if (a.Length > 100) throw new ArgumentException(nameof(a));
}
```

NEA0006 fires and the fix rewrites this to:

```csharp
ArgumentException.ThrowIfLengthGreaterThan(a, 100);
```

which fails to compile with **CS1503** (`int[]` cannot convert to `string`). Since NEA0006 has no `HasBuiltInMember` gate, it fires on every target framework, and a project-wide Fix All (all providers use `WellKnownFixAllProviders.BatchFixer`) would apply this broken rewrite everywhere at once.

### After

The analyzer resolves the receiver's type via the semantic model (`context.SemanticModel.GetTypeInfo(comparison.Value.ValueExpression, context.CancellationToken)`) and only reports when it is `System.String`. The check runs after the existing cheap syntactic gates to preserve the syntax-first ordering on this per-`if`-statement hot path. The `string` case is unaffected and still reports/fixes correctly.

## Test added

`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfLengthAnalyzerTests.cs`:
- `Analyze_WhenLengthReceiverIsNotString_DoesNotReportDiagnostic` — covers `int[]` and `System.Span<char>` receivers.
- `Analyze_WhenLengthReceiverIsUserDefinedTypeWithLengthProperty_DoesNotReportDiagnostic` — covers a user-defined type with a `Length` property.

Both fail before the fix (diagnostic reported for non-string receivers) and pass after.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings/errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — all 106 tests pass, including the new regression tests and the existing `string` positive cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)