### PR TITLE
fix(analyser): pack analyzer DLL to analyzers/dotnet/cs instead of lib

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj
+++ b/src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj
@@ -3,13 +3,21 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <IsPackable>false</IsPackable>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>false</IncludeSymbols>
     <NoWarn>$(NoWarn);RS1038</NoWarn>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
     <Description>Roslyn analyzers and code fixes that promote using NetEvolve.Arguments / BCL throw-helper APIs instead of manual argument-validation `if` blocks, on every target framework supported by NetEvolve.Arguments.</Description>
     <PackageTags>guard;clause;exceptions;argument-validation;analyzer;roslyn;code-fix;argument-exception;argumentnullexception</PackageTags>
     <PackageProjectUrl>https://github.com/dailydevops/arguments</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dailydevops/arguments.git</RepositoryUrl>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="_._" Pack="true" PackagePath="lib\$(TargetFramework)" Visible="false" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
@@ -19,4 +27,9 @@
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
+  <Target Name="_AddAnalyzersToOutput">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).dll" PackagePath="analyzers/dotnet/cs" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Defect

The `NetEvolve.Arguments.Analyser` package assembly was being packed into `lib/netstandard2.0/` instead of `analyzers/dotnet/cs/`. NuGet treats `lib/` content as an ordinary compile/runtime reference, not an analyzer — so Roslyn never loaded the assembly for consumers, and none of the NEA0001-NEA0009 diagnostics ever ran.

Root cause: the csproj set `<IsPackable>false</IsPackable>`, but this was silently overridden during MSBuild evaluation by the `NetEvolve.Defaults` `GlobalPackageReference`, which forces `IsPackable=true` for non-test/non-example projects. Confirmed via:

```
dotnet msbuild src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj -getProperty:IsPackable -getProperty:IncludeBuildOutput
# before fix: IsPackable=true, IncludeBuildOutput=true  -> DLL went to lib/
# after fix:  IsPackable=true, IncludeBuildOutput=false -> DLL routed via _AddAnalyzersToOutput target
```

## Fix

Mirrored the pattern already used by the repository owner's own `NetEvolve.Defaults.Analyzer` project:

- Removed the dead/misleading `<IsPackable>false</IsPackable>`.
- Added `DevelopmentDependency`, `IncludeBuildOutput=false`, `NoPackageAnalysis=true`, `SymbolPackageFormat=snupkg`, `IncludeSymbols=false`.
- Added a `_AddAnalyzersToOutput` target that places the built DLL under `analyzers/dotnet/cs` via `TargetsForTfmSpecificContentInPackage`.
- Added a `lib/$(TargetFramework)/_._` placeholder `None` item (and the corresponding empty `_._` file in the project directory) so NuGet doesn't emit `NU5128` for an analyzer-only package with no `lib` content.

## Before / after (verified with `dotnet pack -c Release`)

Before (on `main`), the nupkg contained:
```
lib/netstandard2.0/NetEvolve.Arguments.Analyser.dll   <-- wrong, not loaded by Roslyn
```

After this change:
```
Archive:  NetEvolve.Arguments.Analyser.1.0.0.nupkg
  Length      Date    Time    Name
---------  ---------- -----   ----
      522  2026-07-30 20:40   _rels/.rels
     1197  2026-07-30 20:40   NetEvolve.Arguments.Analyser.nuspec
     7906  2026-07-30 18:38   README.md
    57344  2026-07-30 18:40   analyzers/dotnet/cs/NetEvolve.Arguments.Analyser.dll
        0  2026-07-30 18:39   lib/netstandard2.0/_._
      588  2026-07-30 20:40   [Content_Types].xml
      948  2026-07-30 20:40   package/services/metadata/core-properties/5440ccc750b145dbbcd97841aff9e00a.psmdcp
---------                     -------
    68505                     7 files
```

- `analyzers/dotnet/cs/NetEvolve.Arguments.Analyser.dll` is now present (Roslyn will load it).
- No `lib/netstandard2.0/NetEvolve.Arguments.Analyser.dll` (only the expected empty `_._` placeholder).

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings, 0 errors.
- `dotnet pack src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj -c Release -o ./local-pack-verify` — succeeds; nupkg entries inspected as above (temp output directory removed afterward, not committed).
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 103/103 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)