### PR TITLE
fix(analyser): gate NEA0008 on a string receiver

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceAnalyzer.cs
@@ -2,6 +2,7 @@ namespace NetEvolve.Arguments.Analyser;
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -49,6 +50,22 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzer : DiagnosticAnalyzer
                 ArgumentExceptionMetadataName,
                 context.CancellationToken,
                 out _
+            )
+        )
+        {
+            return;
+        }
+
+        if (!IsStringReceiver(argument, context.SemanticModel, context.CancellationToken))
+        {
+            return;
+        }
+
+        if (
+            !IsLinqEnumerableAny(
+                (InvocationExpressionSyntax)SyntaxHelpers.Unwrap(ifStatement.Condition),
+                context.SemanticModel,
+                context.CancellationToken
             )
         )
         {
@@ -108,6 +125,36 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzer : DiagnosticAnalyzer
 
         return false;
     }
+
+    /// <summary>
+    /// Determines whether the receiver being validated is a <see cref="string"/>. The <c>Any</c> shape recognized by
+    /// <see cref="TryGetContainsWhiteSpaceTarget"/> matches purely syntactically and also fires on any
+    /// <c>IEnumerable&lt;char&gt;</c> receiver (e.g. <c>char[]</c> or <c>List&lt;char&gt;</c>), for which
+    /// <c>ArgumentException.ThrowIfContainsWhiteSpace(string?)</c> is not an applicable replacement.
+    /// </summary>
+    /// <param name="receiver">The expression being validated, as resolved by <see cref="TryGetContainsWhiteSpaceTarget"/>.</param>
+    /// <param name="semanticModel">The semantic model used to resolve the receiver's type.</param>
+    /// <param name="cancellationToken">The token used to cancel semantic-model lookups.</param>
+    /// <returns><see langword="true"/> if <paramref name="receiver"/> is of type <see cref="string"/>; otherwise, <see langword="false"/>.</returns>
+    private static bool IsStringReceiver(
+        ExpressionSyntax receiver,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken
+    ) => semanticModel.GetTypeInfo(receiver, cancellationToken).Type?.SpecialType == SpecialType.System_String;
+
+    /// <summary>Determines whether an invocation resolves to <see cref="System.Linq.Enumerable.Any{TSource}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, bool})"/>, rather than some other method named <c>Any</c>.</summary>
+    /// <param name="invocation">The invocation expression to inspect.</param>
+    /// <param name="semanticModel">The semantic model used to resolve the invoked method.</param>
+    /// <param name="cancellationToken">The token used to cancel semantic-model lookups.</param>
+    /// <returns><see langword="true"/> if <paramref name="invocation"/> invokes <c>System.Linq.Enumerable.Any</c>; otherwise, <see langword="false"/>.</returns>
+    private static bool IsLinqEnumerableAny(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken
+    ) =>
+        semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
+            is IMethodSymbol { Name: "Any", ContainingType: { } containingType }
+        && containingType.ToDisplayString() == "System.Linq.Enumerable";
 
     /// <summary>Determines whether an expression is a <c>char.IsWhiteSpace</c> member access, either via the <c>char</c> keyword or the <c>Char</c> identifier.</summary>
     /// <param name="expression">The expression to test.</param>

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs
@@ -69,4 +69,28 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzerTests
 
         _ = await Assert.That(diagnostics).IsEmpty();
     }
+
+    [Test]
+    [Arguments("char[]")]
+    [Arguments("System.Collections.Generic.List<char>")]
+    [Arguments("System.Collections.Generic.IEnumerable<char>")]
+    public async Task Analyze_WhenReceiverIsNotString_DoesNotReportDiagnostic(string parameterType)
+    {
+        var source = $$"""
+            using System;
+            using System.Linq;
+
+            class C
+            {
+                void M({{parameterType}} chars)
+                {
+                    if (chars.Any(char.IsWhiteSpace)) throw new ArgumentException(nameof(chars));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfContainsWhiteSpaceAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs
@@ -93,4 +93,93 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzerTests
 
         _ = await Assert.That(diagnostics).IsEmpty();
     }
+
+    [Test]
+    public async Task Analyze_WhenReceiverHasNoResolvableType_DoesNotReportDiagnostic()
+    {
+        // "Predicate" refers to the method group C.Predicate(char), which has no type of its own
+        // (SemanticModel.GetTypeInfo(...).Type is null for it), exercising the null-propagation
+        // branch of IsStringReceiver rather than the "resolved but not string" branch already
+        // covered by Analyze_WhenReceiverIsNotString_DoesNotReportDiagnostic.
+        var source = """
+            using System;
+            using System.Linq;
+
+            class C
+            {
+                static bool Predicate(char c) => char.IsWhiteSpace(c);
+
+                void M()
+                {
+                    if (Predicate.Any(char.IsWhiteSpace)) throw new ArgumentException("argument");
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfContainsWhiteSpaceAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenAnyResolutionIsAmbiguous_DoesNotReportDiagnostic()
+    {
+        // Two equally applicable extension methods named "Any" make the call ambiguous, so
+        // SemanticModel.GetSymbolInfo(...).Symbol is null (CandidateReason.OverloadResolutionFailure).
+        // This exercises the "Symbol is IMethodSymbol" pattern failing in IsLinqEnumerableAny, as
+        // opposed to Analyze_WhenAnyIsNotLinqEnumerableAny_DoesNotReportDiagnostic, where the symbol
+        // resolves unambiguously to a method whose containing type merely isn't Enumerable.
+        var source = """
+            using System;
+            using System.Linq;
+
+            static class CustomExtensionsA
+            {
+                public static bool Any(this string value, Func<char, bool> predicate) => false;
+            }
+
+            static class CustomExtensionsB
+            {
+                public static bool Any(this string value, Func<char, bool> predicate) => false;
+            }
+
+            class C
+            {
+                void M(string argument)
+                {
+                    if (argument.Any(char.IsWhiteSpace)) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfContainsWhiteSpaceAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenAnyIsNotLinqEnumerableAny_DoesNotReportDiagnostic()
+    {
+        var source = """
+            using System;
+            using System.Linq;
+
+            static class CustomExtensions
+            {
+                public static bool Any(this string value, Func<char, bool> predicate) => false;
+            }
+
+            class C
+            {
+                void M(string argument)
+                {
+                    if (argument.Any(char.IsWhiteSpace)) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfContainsWhiteSpaceAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
 }


### PR DESCRIPTION
## Defect

`ThrowIfContainsWhiteSpaceAnalyzer` recognized the `arg.Any(char.IsWhiteSpace)` / `arg.Any(c => char.IsWhiteSpace(c))` shapes purely by identifier text, with no check on the type of the receiver being validated. The semantic model was only used to resolve the thrown exception's type.

The suggested replacement, `ArgumentException.ThrowIfContainsWhiteSpace(string?)`, only accepts a `string`. Because the analyzer had no receiver-type gate, it fired (and offered a code fix) for `char[]`, `List<char>`, and any other `IEnumerable<char>` receiver — producing non-compiling code.

### Before

```csharp
void M(char[] chars)
{
    if (chars.Any(char.IsWhiteSpace)) throw new ArgumentException(nameof(chars));
}
```

NEA0008 fired here, and applying the code fix rewrote the body to:

```csharp
ArgumentException.ThrowIfContainsWhiteSpace(chars);
```

which fails to compile with **CS1503** (`char[]` cannot convert to `string`). The same happened for `List<char>` / `IEnumerable<char>` receivers, and — since NEA0008 has no `HasBuiltInMember` gate — on every target framework, including .NET 10. A project-scope Fix All (`BatchFixer`) would have broken every such call site at once.

### After

The same `char[]`/`List<char>`/`IEnumerable<char>` cases no longer report a diagnostic. `string` receivers are unaffected and still report/fix correctly.

## Fix

In `ThrowIfContainsWhiteSpaceAnalyzer.Analyze`, after the existing syntactic shape match and thrown-exception check, added two semantic gates using the `SemanticModel`/`CancellationToken` already in `context`:

1. `IsStringReceiver` — resolves the validated receiver's type via `semanticModel.GetTypeInfo(...)` and requires `SpecialType.System_String`.
2. `IsLinqEnumerableAny` — resolves the invoked `Any` via `semanticModel.GetSymbolInfo(...)` and requires it be `System.Linq.Enumerable.Any` (not merely any method named `Any`), per the task's suggestion. This additionally guards against a hypothetical user-defined `Any` extension/instance method on a string-like type.

Both checks run after the cheap syntactic gates, and `context.CancellationToken` is threaded through both new helpers.

The syntactic matcher `TryGetContainsWhiteSpaceTarget` (also called by `ThrowIfContainsWhiteSpaceCodeFixProvider`) was left untouched to keep this PR scoped to the analyzer file — since the code fix only runs on an already-reported (now string-gated) diagnostic, no change was needed there.

## Test added

`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs`:

- New `Analyze_WhenReceiverIsNotString_DoesNotReportDiagnostic` theory, parameterized over `char[]`, `List<char>`, and `IEnumerable<char>` receivers — asserts no diagnostic is reported for the `chars.Any(char.IsWhiteSpace)` shape from the defect report.
- Confirmed the existing positive `string` cases (`Analyze_WhenWhiteSpaceCheckThrowsArgumentException_ReportsDiagnosticAndFixes`) still report and still fix correctly.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings/errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 106/106 passed (including the new regression tests, verified they fail without the fix and pass with it).
