### PR TITLE
fix(analyser): dispatch NEA0001 fix by diagnostic shape, not ancestor if

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
@@ -40,12 +40,12 @@ public sealed class ThrowIfNullCodeFixProvider : CodeFixProvider
         var diagnostic = context.Diagnostics[0];
         var node = root.FindNode(diagnostic.Location.SourceSpan);
 
-        if (node.FirstAncestorOrSelf<IfStatementSyntax>() is { } ifStatement)
+        if (node is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.CoalesceExpression } coalesce)
         {
             context.RegisterCodeFix(
                 CodeAction.Create(
                     Title,
-                    cancellationToken => ApplyIfStatementFixAsync(context.Document, ifStatement, cancellationToken),
+                    cancellationToken => ApplyCoalesceFixAsync(context.Document, coalesce, cancellationToken),
                     equivalenceKey: Title
                 ),
                 diagnostic
@@ -53,12 +53,12 @@ public sealed class ThrowIfNullCodeFixProvider : CodeFixProvider
             return;
         }
 
-        if (node is BinaryExpressionSyntax { RawKind: (int)SyntaxKind.CoalesceExpression } coalesce)
+        if (node.FirstAncestorOrSelf<IfStatementSyntax>() is { } ifStatement)
         {
             context.RegisterCodeFix(
                 CodeAction.Create(
                     Title,
-                    cancellationToken => ApplyCoalesceFixAsync(context.Document, coalesce, cancellationToken),
+                    cancellationToken => ApplyIfStatementFixAsync(context.Document, ifStatement, cancellationToken),
                     equivalenceKey: Title
                 ),
                 diagnostic
@@ -83,6 +83,7 @@ public sealed class ThrowIfNullCodeFixProvider : CodeFixProvider
             root is null
             || !SyntaxHelpers.TryGetNullCheckedExpression(ifStatement.Condition, out var argument)
             || argument is null
+            || SyntaxHelpers.GetSingleThrowStatement(ifStatement.Statement) is null
         )
         {
             return document;

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -263,6 +263,64 @@ public sealed class ThrowIfNullAnalyzerTests
     }
 
     [Test]
+    public async Task CodeFix_WhenCoalesceIsNestedInsideIfStatement_HoistsThrowIfNullAndKeepsAssignment()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? target, string? source)
+                {
+                    if (target is null)
+                    {
+                        target = source ?? throw new ArgumentNullException(nameof(source));
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(source);");
+        _ = await Assert.That(fixedSource).Contains("target = source;");
+        _ = await Assert.That(fixedSource).DoesNotContain("throw new ArgumentNullException");
+    }
+
+    [Test]
+    public async Task CodeFix_WhenCoalesceIsNestedInsideUnrelatedIfStatement_StillAppliesCoalesceFix()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(bool flag, string? source)
+                {
+                    if (flag)
+                    {
+                        var value = source ?? throw new ArgumentNullException(nameof(source));
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(source);");
+        _ = await Assert.That(fixedSource).Contains("var value = source;");
+        _ = await Assert.That(fixedSource).DoesNotContain("throw new ArgumentNullException");
+    }
+
+    [Test]
     public async Task CodeFix_WhenApplied_ReplacesWithThrowIfNullCall()
     {
         const string source = """


### PR DESCRIPTION
## Defect

`ThrowIfNullCodeFixProvider.RegisterCodeFixesAsync` dispatched between the two NEA0001 fix paths by checking `node.FirstAncestorOrSelf<IfStatementSyntax>()` *before* checking whether the diagnostic node was actually a coalesce (`??`) expression. Because `FirstAncestorOrSelf` walks up unbounded, any `??`-throw diagnostic nested anywhere inside an `if` statement took the if-statement fix path — even though the diagnostic was reported on the coalesce expression, not the `if`.

This caused two symptoms:

1. **Silent data loss** when the enclosing `if` happened to be a recognized null check. Example:

   ```csharp
   void M(string? target, string? source)
   {
       if (target is null)
       {
           target = source ?? throw new ArgumentNullException(nameof(source));
       }
   }
   ```

   Before the fix, applying the NEA0001 code fix produced just:

   ```csharp
   void M(string? target, string? source)
   {
       if (target is null)
       {
           ArgumentNullException.ThrowIfNull(target);
       }
   }
   ```

   `target = source` was silently deleted, and the fix operated on the wrong argument (`target` instead of `source`).

2. **Silent no-op** when the enclosing `if` was not a recognized null check (e.g. `if (flag) { ... }`) — the lightbulb appeared but applying it left the document unchanged, because `ApplyIfStatementFixAsync` couldn't match the `if` condition and bailed out, while the correct coalesce fix was never attempted.

Additionally, `ApplyIfStatementFixAsync` only re-validated the `if` **condition** before replacing the whole `if` statement — it never re-checked that the `if` body was still a lone `throw` (that guard previously lived only in the analyzer, via `SyntaxHelpers.TryGetThrownException`/`GetSingleThrowStatement`). A mis-routed or stale fix invocation could therefore destructively replace an `if` block whose body was not a lone throw.

## Fix

Two surgical changes in `src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs`:

1. `RegisterCodeFixesAsync` now dispatches on the diagnostic node's shape first: it checks for a `BinaryExpressionSyntax` with `CoalesceExpression` kind *before* walking up for an enclosing `if` statement. A coalesce diagnostic is now always routed to `ApplyCoalesceFixAsync`, regardless of what `if` statements happen to enclose it.
2. `ApplyIfStatementFixAsync` now also calls `SyntaxHelpers.GetSingleThrowStatement(ifStatement.Statement)` and bails out (returns the unchanged document) if the `if` body is not a lone `throw`, so a stale or mis-routed invocation degrades to a no-op instead of a destructive edit.

## Tests added

In `tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs`:

- `CodeFix_WhenCoalesceIsNestedInsideIfStatement_HoistsThrowIfNullAndKeepsAssignment` — reproduces the data-loss case above; asserts the fixed source still contains `target = source;` and does not contain the original `throw new ArgumentNullException`.
- `CodeFix_WhenCoalesceIsNestedInsideUnrelatedIfStatement_StillAppliesCoalesceFix` — a `??`-throw nested inside `if (flag) { ... }`; asserts the coalesce fix is actually applied (hoisted `ThrowIfNull` call + preserved `var value = source;`) instead of being a silent no-op.

Both tests fail against the pre-fix dispatch logic and pass after the fix.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeded, 0 warnings/errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 105/105 passed.

## Out of scope (tracked separately, not touched here)

- Coalesce fix hoisting out of lambdas/ternaries.
- Leading-trivia duplication in the coalesce fix's inserted statement.
- Embedded-statement / `InsertBefore` list assumptions.
- Unqualified exception names / missing `using System;` in generated code.
- Dropped comments in the replaced `if` block.
