### PR TITLE
fix(analyser): suppress NEA0005 for static outer scopes of nested functions

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfDisposedAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfDisposedAnalyzer.cs
@@ -59,9 +59,30 @@ public sealed class ThrowIfDisposedAnalyzer : DiagnosticAnalyzer
             context.CancellationToken
         );
 
-        if (enclosingSymbol is null || enclosingSymbol.IsStatic)
+        if (enclosingSymbol is null)
         {
             return;
+        }
+
+        // Walk up through local functions and lambdas: `IsStatic` on the innermost enclosing
+        // symbol only reflects the `static` modifier written on that local function/lambda
+        // itself, not on the member that contains it. The fix requires `this`, so bail out if
+        // any enclosing scope - the local function/lambda chain or the member containing it -
+        // is static.
+        var symbol = enclosingSymbol;
+        while (symbol is not null)
+        {
+            if (symbol.IsStatic)
+            {
+                return;
+            }
+
+            if (symbol is not IMethodSymbol { MethodKind: MethodKind.LocalFunction or MethodKind.AnonymousFunction })
+            {
+                break;
+            }
+
+            symbol = symbol.ContainingSymbol;
         }
 
         if (

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDisposedAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDisposedAnalyzerTests.cs
@@ -48,6 +48,88 @@ public sealed class ThrowIfDisposedAnalyzerTests
     }
 
     [Test]
+    public async Task Analyze_WhenInLocalFunctionInsideStaticMethod_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private static bool _disposed;
+
+                static void M()
+                {
+                    void Check()
+                    {
+                        if (_disposed) throw new ObjectDisposedException(nameof(C));
+                    }
+
+                    Check();
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfDisposedAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenInLambdaInsideStaticMethod_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private static bool _disposed;
+
+                static void M()
+                {
+                    Action check = () =>
+                    {
+                        if (_disposed) throw new ObjectDisposedException(nameof(C));
+                    };
+
+                    check();
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfDisposedAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenInLocalFunctionInsideInstanceMethod_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private bool _disposed;
+
+                void M()
+                {
+                    void Check()
+                    {
+                        if (_disposed) throw new ObjectDisposedException(nameof(C));
+                    }
+
+                    Check();
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfDisposedAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0005");
+    }
+
+    [Test]
     [Arguments("if (_disposed) throw new ArgumentException(\"disposed\");")]
     [Arguments(
         """


### PR DESCRIPTION
## Defect

`ThrowIfDisposedAnalyzer.cs:62` used `enclosingSymbol.IsStatic` as its only static guard:

```csharp
if (enclosingSymbol is null || enclosingSymbol.IsStatic) { return; }
```

For a position inside a **local function** or **lambda**, `GetEnclosingSymbol` returns that nested function, whose `IsStatic` reflects only the `static` modifier written on IT — not on the containing member. `ThrowIfDisposedCodeFixProvider.cs:88` then unconditionally appends `SyntaxFactory.ThisExpression()`.

### Before (fails to compile after the fix is applied)

```csharp
static void M()
{
    void Check()
    {
        if (_disposed) throw new ObjectDisposedException(nameof(C));
    }
}
```

`Check` has `IsStatic == false`, so NEA0005 was reported, and the code fix emitted:

```csharp
ObjectDisposedException.ThrowIf(_disposed, this); // CS0026: keyword 'this' is not available in the current context
```

The same problem occurs for a non-`static` lambda declared inside a `static` member.

### After

The analyzer now walks up the `ContainingSymbol` chain through local functions and anonymous functions (lambdas), checking `IsStatic` at every level, and bails out (no diagnostic) if any enclosing scope — including the member that ultimately contains the nested function/lambda — is static. A local function/lambda inside an **instance** member still reports correctly, since none of the enclosing scopes are static.

## Fix chosen

Option (a) from the assignment: minimal, analyzer-only change — walk `enclosingSymbol` up through local functions/lambdas and bail if any enclosing scope is static. This keeps `ThrowIfDisposedCodeFixProvider.cs` untouched. Option (b) (emit `typeof(T)` and use the `ThrowIf(bool, Type)` overload to keep reporting in static contexts) would give a better UX but touches the fix provider and is a larger change than needed to fix this defect; not pursued here.

## Tests added

In `tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDisposedAnalyzerTests.cs`:
- `Analyze_WhenInLocalFunctionInsideStaticMethod_DoesNotReportDiagnostic` (negative — reproduces the CS0026 scenario, was reporting before the fix)
- `Analyze_WhenInLambdaInsideStaticMethod_DoesNotReportDiagnostic` (negative — lambda variant)
- `Analyze_WhenInLocalFunctionInsideInstanceMethod_ReportsDiagnostic` (positive — proves the fix isn't over-broad; a local function inside an instance member must still report)

All three use the default (legacy) reference set from `AnalyzerVerifier`, matching the existing tests, since NEA0005 self-disables on .NET 7+ via the `HasBuiltInMember` gate.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings/errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 106/106 passed (all pre-existing tests still green, plus the 3 new regression tests).

## Out of scope (tracked separately, owned by other agents)

- The exception-constructor-argument / custom-message validation for NEA0005.
- The semantic-call-before-syntax-gate ordering nit at `ThrowIfDisposedAnalyzer.cs:57`.
