### PR TITLE
fix(analyser): gate NEA0003 on operand type implementing IEquatable<T>/IComparable<T>

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeAnalyzer.cs
@@ -2,6 +2,8 @@ namespace NetEvolve.Arguments.Analyser;
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -13,6 +15,12 @@ public sealed class ThrowIfOutOfRangeAnalyzer : DiagnosticAnalyzer
 {
     /// <summary>The fully-qualified metadata name of <see cref="ArgumentOutOfRangeException"/>.</summary>
     private const string ArgumentOutOfRangeExceptionMetadataName = "System.ArgumentOutOfRangeException";
+
+    /// <summary>The fully-qualified metadata name of the open generic <see cref="IEquatable{T}"/> interface.</summary>
+    private const string EquatableMetadataName = "System.IEquatable`1";
+
+    /// <summary>The fully-qualified metadata name of the open generic <see cref="IComparable{T}"/> interface.</summary>
+    private const string ComparableMetadataName = "System.IComparable`1";
 
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
@@ -71,6 +79,11 @@ public sealed class ThrowIfOutOfRangeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        if (!IsSupportedOperandType(comparison.Value, context.SemanticModel, context.CancellationToken))
+        {
+            return;
+        }
+
         var value = comparison.Value;
         string args;
 
@@ -94,6 +107,48 @@ public sealed class ThrowIfOutOfRangeAnalyzer : DiagnosticAnalyzer
                 value.HelperName,
                 args
             )
+        );
+    }
+
+    /// <summary>
+    /// Determines whether the compared operand's type actually satisfies the generic constraint of the
+    /// <see cref="ArgumentOutOfRangeException"/> throw-helper the comparison would be rewritten to, so that
+    /// the rewritten call is guaranteed to compile.
+    /// </summary>
+    /// <param name="comparison">The recognized comparison.</param>
+    /// <param name="semanticModel">The semantic model used to resolve the operand's type.</param>
+    /// <param name="cancellationToken">The token used to cancel type resolution.</param>
+    /// <returns><see langword="true"/> if the operand type implements the required generic interface closed over itself; otherwise, <see langword="false"/>.</returns>
+    private static bool IsSupportedOperandType(
+        ComparisonResult comparison,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken
+    )
+    {
+        var operandType = semanticModel.GetTypeInfo(comparison.ValueExpression, cancellationToken).Type;
+
+        if (operandType is null || operandType.TypeKind == TypeKind.Error)
+        {
+            return false;
+        }
+
+        var requiredInterfaceMetadataName = comparison.HelperName is "ThrowIfEqual" or "ThrowIfNotEqual"
+            ? EquatableMetadataName
+            : ComparableMetadataName;
+
+        var unconstructedRequiredInterface = semanticModel.Compilation.GetTypeByMetadataName(
+            requiredInterfaceMetadataName
+        );
+
+        if (unconstructedRequiredInterface is null)
+        {
+            return false;
+        }
+
+        var requiredInterface = unconstructedRequiredInterface.Construct(operandType);
+
+        return operandType.AllInterfaces.Any(implementedInterface =>
+            SymbolEqualityComparer.Default.Equals(implementedInterface, requiredInterface)
         );
     }
 

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
@@ -305,4 +305,24 @@ public sealed class ThrowIfOutOfRangeAnalyzerTests
 
         _ = await Assert.That(diagnostics).IsEmpty();
     }
+
+    [Test]
+    public async Task Analyze_WhenOperandTypeIsUnresolvedErrorType_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(Undeclared argument)
+                {
+                    if (argument < 0) throw new ArgumentOutOfRangeException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
@@ -236,4 +236,73 @@ public sealed class ThrowIfOutOfRangeAnalyzerTests
 
         _ = await Assert.That(diagnostics).IsEmpty();
     }
+
+    [Test]
+    public async Task Analyze_WhenOperandIsEnumComparedForEquality_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            enum Kind
+            {
+                None,
+            }
+
+            class C
+            {
+                void M(Kind argument)
+                {
+                    if (argument == Kind.None) throw new ArgumentOutOfRangeException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenOperandIsObject_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(object argument, object other)
+                {
+                    if (argument == other) throw new ArgumentOutOfRangeException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenOperandTypeImplementsNeitherEquatableNorComparable_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class UnsupportedType
+            {
+            }
+
+            class C
+            {
+                void M(UnsupportedType argument, UnsupportedType other)
+                {
+                    if (argument == other) throw new ArgumentOutOfRangeException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
 }


### PR DESCRIPTION
## Defect

`ThrowIfOutOfRangeAnalyzer` (rule NEA0003) recognized a comparison-then-throw pattern purely by switching on the binary operator's `SyntaxKind` (`ThrowIfOutOfRangeAnalyzer.cs:132-148`). It never checked that the compared operand's type actually satisfies the generic constraint of the `ArgumentOutOfRangeException` throw-helper it maps to:

- `ThrowIfEqual<T>` / `ThrowIfNotEqual<T>` require `T : IEquatable<T>?`
- the relational helpers (`ThrowIfLessThan`, `ThrowIfGreaterThan`, `ThrowIfOutOfRange`, …) require `T : IComparable<T>`

(see `src/NetEvolve.Arguments/ArgumentOutOfRangeExceptionPolyfills.cs`)

### Before

```csharp
enum Kind { None }

void M(Kind k)
{
    if (k == Kind.None) throw new ArgumentOutOfRangeException(nameof(k));
}
```

NEA0003 fired and the code fix rewrote this to:

```csharp
ArgumentOutOfRangeException.ThrowIfEqual(k, Kind.None);
```

which fails to compile with **CS0311**, because `Kind` does not implement `IEquatable<Kind>`. The same problem applies to `object` operands and any user-defined type lacking the relevant interface.

### After

The analyzer resolves the compared operand's type via `context.SemanticModel.GetTypeInfo(...)` and requires it to implement `System.IEquatable<T>` (equality path) or `System.IComparable<T>` (relational/combined-range path), closed over itself. The required interface is resolved via `Compilation.GetTypeByMetadataName`, constructed over the operand type, and matched against the type's `AllInterfaces` using `SymbolEqualityComparer.Default` (no string-based interface matching). The enum example above, `object` operands, and types implementing neither interface no longer report NEA0003.

## Test added

`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs`:
- `Analyze_WhenOperandIsEnumComparedForEquality_DoesNotReportDiagnostic`
- `Analyze_WhenOperandIsObject_DoesNotReportDiagnostic`
- `Analyze_WhenOperandTypeImplementsNeitherEquatableNorComparable_DoesNotReportDiagnostic`

Confirmed the existing `int`-based positive cases (`Analyze_WhenComparisonThrowsArgumentOutOfRangeException_ReportsDiagnosticAndFixes`, combined-range test, etc.) still report, since `int` implements both `IEquatable<int>` and `IComparable<int>`.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings, 0 errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 106/106 passed.

## Out of scope

The following related findings are tracked and fixed separately, and are not touched here:
- NaN / floating-point comparison semantics for `double`/`float`
- `paramName` / exception-constructor-argument validation gap
- the `AreEquivalent` textual-identity issue for side-effecting operands
