### PR TITLE
fix(analyser): gate NEA0004 on ThrowIfDefault's struct+IEquatable constraint

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfDefaultAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfDefaultAnalyzer.cs
@@ -2,6 +2,8 @@ namespace NetEvolve.Arguments.Analyser;
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -60,9 +62,52 @@ public sealed class ThrowIfDefaultAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        if (!SatisfiesThrowIfDefaultConstraint(context.SemanticModel, argument, context.CancellationToken))
+        {
+            return;
+        }
+
         context.ReportDiagnostic(
             Diagnostic.Create(DiagnosticDescriptors.ThrowIfDefault, ifStatement.GetLocation(), argument.ToString())
         );
+    }
+
+    /// <summary>
+    /// Determines whether the type of <paramref name="argument"/> satisfies the constraint of
+    /// <c>ArgumentException.ThrowIfDefault&lt;T&gt;(T)</c>, namely <c>where T : struct, IEquatable&lt;T&gt;</c>.
+    /// </summary>
+    /// <param name="semanticModel">The semantic model used to resolve the argument's type.</param>
+    /// <param name="argument">The expression being validated.</param>
+    /// <param name="cancellationToken">The token used to cancel semantic-model lookups.</param>
+    /// <returns><see langword="true"/> if the argument's type is a non-nullable value type implementing <c>IEquatable&lt;T&gt;</c> closed over itself; otherwise, <see langword="false"/>.</returns>
+    private static bool SatisfiesThrowIfDefaultConstraint(
+        SemanticModel semanticModel,
+        ExpressionSyntax argument,
+        CancellationToken cancellationToken
+    )
+    {
+        var type = semanticModel.GetTypeInfo(argument, cancellationToken).Type;
+
+        if (type is null || !type.IsValueType)
+        {
+            return false;
+        }
+
+        if (type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            return false;
+        }
+
+        var equatableType = semanticModel.Compilation.GetTypeByMetadataName("System.IEquatable`1");
+
+        if (equatableType is null)
+        {
+            return false;
+        }
+
+        var constructedEquatable = equatableType.Construct(type);
+
+        return type.AllInterfaces.Contains(constructedEquatable, SymbolEqualityComparer.Default);
     }
 
     /// <summary>Recognizes <c>arg.Equals(default)</c>/<c>arg.Equals(default(T))</c> and <c>arg == default</c>/<c>default == arg</c> (and the <c>default(T)</c> variants).</summary>

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDefaultAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDefaultAnalyzerTests.cs
@@ -63,6 +63,70 @@ public sealed class ThrowIfDefaultAnalyzerTests
     }
 
     [Test]
+    public async Task Analyze_WhenArgumentTypeIsReferenceType_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string argument)
+                {
+                    if (argument == default) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfDefaultAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenArgumentTypeIsNullableValueType_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(Guid? argument)
+                {
+                    if (argument == default) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfDefaultAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenArgumentTypeIsStructWithoutIEquatable_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            struct S
+            {
+            }
+
+            class C
+            {
+                void M(S argument)
+                {
+                    if (argument.Equals(default)) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfDefaultAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task Analyze_WhenParamNameIsStringLiteral_ReportsDiagnostic()
     {
         const string source = """


### PR DESCRIPTION
## Defect

`ThrowIfDefaultAnalyzer` (rule NEA0004) matched `arg == default` / `arg.Equals(default)` purely syntactically via `SyntaxHelpers.IsDefaultLiteral`, which takes no `SemanticModel` and matches `default`/`default(T)` for **any** `T`. The type of the validated expression was never resolved against the constraint of the helper the fix targets:

```csharp
public static void ThrowIfDefault<T>(T argument, ...) where T : struct, IEquatable<T>
```

So the analyzer reported NEA0004 and offered a code fix even when the resulting call would not compile.

### Before (reports NEA0004, code fix produces non-compiling code)

```csharp
void M(string a)
{
    if (a == default) throw new ArgumentException(nameof(a));
}
```

Applying the code fix produced `ArgumentException.ThrowIfDefault(a);`, which fails with **CS0453** (`string` is not a non-nullable value type). The same problem affects `Guid?` (nullable value type → CS0453) and any plain struct that does not implement `IEquatable<T>` for itself (→ CS0311).

### After

The three cases above no longer report NEA0004. The existing `Guid`-based positive cases are unaffected, since `Guid` is a non-nullable value type implementing `IEquatable<Guid>`.

## Fix

In `ThrowIfDefaultAnalyzer.Analyze`, after the existing syntactic gates, resolve the checked expression's type via `context.SemanticModel.GetTypeInfo(...)` and only report when:
- the type is a value type and not `Nullable<T>` (checked via `OriginalDefinition.SpecialType == SpecialType.System_Nullable_T`), and
- the type's `AllInterfaces` contains `System.IEquatable<T>` constructed over itself, resolved via `Compilation.GetTypeByMetadataName("System.IEquatable\`1")` and compared with `SymbolEqualityComparer.Default` (not by name).

`SyntaxHelpers.IsDefaultLiteral` and `SyntaxHelpers.cs` were left untouched, per scope — the new gate lives entirely in `ThrowIfDefaultAnalyzer.cs`.

### Note on scope of the change

The gate also silences NEA0004 for `enum` arguments (a non-nullable value type, but `System.Enum` does not implement `IEquatable<T>` for the enum type itself), which is correct given the same CS0311 would result. No existing tests covered enums, so nothing regresses, but flagging this as an intentional consequence of the fix rather than an incidental one.

## Test added

`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDefaultAnalyzerTests.cs`:
- `Analyze_WhenArgumentTypeIsReferenceType_DoesNotReportDiagnostic` — `string` parameter, the exact repro from the defect report.
- `Analyze_WhenArgumentTypeIsNullableValueType_DoesNotReportDiagnostic` — `Guid?` parameter.
- `Analyze_WhenArgumentTypeIsStructWithoutIEquatable_DoesNotReportDiagnostic` — a plain `struct S {}` with no `IEquatable<S>`.

All three were confirmed to **fail** against the pre-fix analyzer (reporting NEA0004) and **pass** after the fix. Existing `Guid`-based positive tests continue to pass.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 106/106 passed.
