### PR TITLE
fix(analyser): exclude IEEE floating-point operands from NEA0003 relational rewrites

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeAnalyzer.cs
@@ -22,6 +22,29 @@ public sealed class ThrowIfOutOfRangeAnalyzer : DiagnosticAnalyzer
     /// <summary>The fully-qualified metadata name of the open generic <see cref="IComparable{T}"/> interface.</summary>
     private const string ComparableMetadataName = "System.IComparable`1";
 
+    /// <summary>The fully-qualified metadata name of <c>System.Half</c>.</summary>
+    private const string HalfMetadataName = "System.Half";
+
+    /// <summary>
+    /// The throw-helper members whose implementation relies on <see cref="IComparable{T}.CompareTo"/>. For IEEE
+    /// floating-point operands (<see cref="float"/>, <see cref="double"/>, <c>System.Half</c>), <c>CompareTo</c>
+    /// disagrees with the relational operators on <c>NaN</c>: e.g. <c>double.NaN.CompareTo(5.0)</c> is negative,
+    /// while <c>double.NaN &lt; 5.0</c> is <see langword="false"/>. Rewriting such a comparison into the matching
+    /// throw-helper would silently change which values throw, so these helpers are excluded for those operand types.
+    /// <c>ThrowIfEqual</c>/<c>ThrowIfNotEqual</c> (backed by <see cref="EqualityComparer{T}"/>) and <c>ThrowIfZero</c>
+    /// (backed by <c>INumberBase&lt;T&gt;.IsZero</c>) do not have this divergence and are intentionally not listed.
+    /// </summary>
+    private static readonly ImmutableHashSet<string> NaNSensitiveHelperNames = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "ThrowIfNegative",
+        "ThrowIfNegativeOrZero",
+        "ThrowIfLessThan",
+        "ThrowIfLessThanOrEqual",
+        "ThrowIfGreaterThan",
+        "ThrowIfGreaterThanOrEqual",
+        "ThrowIfOutOfRange"
+    );
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(DiagnosticDescriptors.ThrowIfOutOfRange);
@@ -60,6 +83,18 @@ public sealed class ThrowIfOutOfRangeAnalyzer : DiagnosticAnalyzer
         var ifStatement = (IfStatementSyntax)context.Node;
 
         if (!TryGetComparison(ifStatement.Condition, out var comparison) || comparison is null)
+        {
+            return;
+        }
+
+        if (
+            NaNSensitiveHelperNames.Contains(comparison.Value.HelperName)
+            && IsIeeeFloatingPointOperand(
+                context.SemanticModel,
+                comparison.Value.ValueExpression,
+                context.CancellationToken
+            )
+        )
         {
             return;
         }
@@ -150,6 +185,39 @@ public sealed class ThrowIfOutOfRangeAnalyzer : DiagnosticAnalyzer
         return operandType.AllInterfaces.Any(implementedInterface =>
             SymbolEqualityComparer.Default.Equals(implementedInterface, requiredInterface)
         );
+    }
+
+    /// <summary>
+    /// Determines whether an operand's type is an IEEE floating-point type (<see cref="float"/>, <see cref="double"/>,
+    /// or <c>System.Half</c>) — the types for which <see cref="IComparable{T}.CompareTo"/> and the relational
+    /// operators disagree on <c>NaN</c>.
+    /// </summary>
+    /// <param name="semanticModel">The semantic model used to resolve the operand's type.</param>
+    /// <param name="operand">The compared expression whose type is inspected.</param>
+    /// <param name="cancellationToken">The token used to cancel semantic-model lookups.</param>
+    /// <returns><see langword="true"/> if <paramref name="operand"/>'s type is <see cref="float"/>, <see cref="double"/>, or <c>System.Half</c>; otherwise, <see langword="false"/>.</returns>
+    private static bool IsIeeeFloatingPointOperand(
+        SemanticModel semanticModel,
+        ExpressionSyntax operand,
+        CancellationToken cancellationToken
+    )
+    {
+        var type = semanticModel.GetTypeInfo(operand, cancellationToken).Type;
+
+        if (type is null)
+        {
+            return false;
+        }
+
+        if (type.SpecialType is SpecialType.System_Single or SpecialType.System_Double)
+        {
+            return true;
+        }
+
+        // System.Half has no SpecialType and may not exist on older target frameworks, so a null lookup is normal.
+        var halfType = semanticModel.Compilation.GetTypeByMetadataName(HalfMetadataName);
+
+        return halfType is not null && SymbolEqualityComparer.Default.Equals(type, halfType);
     }
 
     /// <summary>

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
@@ -165,6 +165,71 @@ public sealed class ThrowIfOutOfRangeAnalyzerTests
     }
 
     [Test]
+    public async Task Analyze_WhenCombinedRangeOperandIsDouble_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(double argument)
+                {
+                    if (argument < 5 || argument > 100) throw new ArgumentOutOfRangeException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    [Arguments("argument < 42")]
+    [Arguments("argument <= 42")]
+    [Arguments("argument > 42")]
+    [Arguments("argument >= 42")]
+    public async Task Analyze_WhenRelationalOperandIsFloat_DoesNotReportDiagnostic(string condition)
+    {
+        var source = $$"""
+            using System;
+
+            class C
+            {
+                void M(float argument)
+                {
+                    if ({{condition}}) throw new ArgumentOutOfRangeException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenEqualityOperandIsDouble_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(double argument)
+                {
+                    if (argument == 42) throw new ArgumentOutOfRangeException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0003");
+    }
+
+    [Test]
     public async Task Analyze_WhenIfHasElseClause_DoesNotReportDiagnostic()
     {
         const string source = """


### PR DESCRIPTION
**Note on expected conflict:** another agent is concurrently adding IEquatable/IComparable operand-type gating to `ThrowIfOutOfRangeAnalyzer.cs` in a separate PR (separate finding). This PR touches the same file; the repository owner has accepted that these two PRs may conflict and expects them to be merged/rebased sequentially — this is not an oversight.

## Defect (NEA0003, MEDIUM)

`ThrowIfOutOfRangeAnalyzer` rewrote relational and combined-range comparison-then-throw patterns into `ArgumentOutOfRangeException` throw-helper calls without inspecting the compared operand's type. The throw-helpers (`ThrowIfNegative`, `ThrowIfLessThan`, `ThrowIfGreaterThan`, `ThrowIfOutOfRange`, etc. — see `src/NetEvolve.Arguments/ArgumentOutOfRangeExceptionPolyfills.cs`) are implemented via `IComparable<T>.CompareTo`, which disagrees with the IEEE relational operators (`<`, `>`) on `NaN`:

- `double.NaN < 5.0` → `false`
- `double.NaN.CompareTo(5.0)` → negative (i.e. "less than")

So for `float`/`double`/`Half` operands, applying the suggested fix silently changes which inputs throw.

### Before / after example

```csharp
void M(double a)
{
    if (a < 5 || a > 100) throw new ArgumentOutOfRangeException(nameof(a));
}
```

Before the fix (original code): `M(double.NaN)` throws nothing (`NaN < 5` and `NaN > 100` are both `false`).

Applying NEA0003's suggested fix rewrote this to:

```csharp
ArgumentOutOfRangeException.ThrowIfOutOfRange(a, 5, 100);
```

After the fix: `M(double.NaN)` throws, because `NaN.CompareTo(5)` is negative. This is a silent behavior change introduced purely by accepting the analyzer's fix.

**Mitigating context:** the real .NET 8+ BCL `ArgumentOutOfRangeException.ThrowIfOutOfRange` (and siblings) have this exact same `CompareTo`-based semantics, so this divergence is standard throw-helper behavior, not a repo-specific inversion — hence MEDIUM, not HIGH. Still, the analyzer shouldn't silently rewrite working code into code with different runtime behavior for these operand types.

## Fix

In `ThrowIfOutOfRangeAnalyzer.Analyze`, after a comparison shape is recognized, the compared operand's type is resolved via `context.SemanticModel.GetTypeInfo(...)`. If the type is `float`, `double`, or `System.Half` (resolved via `compilation.GetTypeByMetadataName("System.Half")`, since it has no `SpecialType` and may not exist on older target frameworks — a null result is expected and handled), the diagnostic is **not reported** at all (option (a) from the brief) for the NaN-sensitive helpers:

`ThrowIfNegative`, `ThrowIfNegativeOrZero`, `ThrowIfLessThan`, `ThrowIfLessThanOrEqual`, `ThrowIfGreaterThan`, `ThrowIfGreaterThanOrEqual`, `ThrowIfOutOfRange`.

Option (a) (suppress the diagnostic) was chosen over (b) (report but suppress the fix) because it's simpler, matches how the other rules in this analyzer already gate (e.g. staying silent when the BCL already exposes the throw-helper), and avoids reporting a diagnostic the user can never actually apply.

### Scoping: why `==`/`!=` (and `ThrowIfZero`) are NOT excluded

- `ThrowIfEqual`/`ThrowIfNotEqual` are backed by `EqualityComparer<T>.Default.Equals`, not `CompareTo`. `double.Equals(NaN, NaN)` is `true` (bitwise/IEEE-754-2008 semantics used by `IEquatable<double>.Equals`), matching `==`'s general behavior for identical NaN patterns closely enough that this analyzer's scope — the relational/combined-range paths — does not need to gate it. This defect is specifically about `CompareTo` vs. `<`/`>`, which only affects the relational helpers and the combined-range `ThrowIfOutOfRange` helper.
- `ThrowIfZero` is backed by `INumberBase<T>.IsZero`, which is `false` for `NaN`, matching `value == 0`'s behavior (`NaN == 0` is also `false`). No divergence, no exclusion needed.

So the exclusion is scoped precisely to the helpers whose polyfill implementation calls `CompareTo`: `ThrowIfNegative(OrZero)`, `ThrowIfLessThan(OrEqual)`, `ThrowIfGreaterThan(OrEqual)`, and `ThrowIfOutOfRange`.

## Tests added (`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs`)

- `Analyze_WhenCombinedRangeOperandIsDouble_DoesNotReportDiagnostic` — the exact repro from the defect report (`double` operand, combined range).
- `Analyze_WhenRelationalOperandIsFloat_DoesNotReportDiagnostic` — parameterized over `<`, `<=`, `>`, `>=` with a `float` operand.
- `Analyze_WhenEqualityOperandIsDouble_ReportsDiagnostic` — confirms `==` on a `double` operand is *not* excluded (diagnostic still reported), validating the narrow scoping decision above.
- Existing positive `int` cases (relational, combined-range, etc.) continue to pass unchanged, confirming no regression for non-floating-point operands.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings, 0 errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 109/109 passed (0 failed, 0 skipped).
