### PR TITLE
fix(analyser): suppress NEA0001 for coalesce-throws that cannot be safely hoisted

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullAnalyzer.cs
@@ -69,9 +69,58 @@ public sealed class ThrowIfNullAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        if (IsConditionallyEvaluatedRelativeToContainingStatement(binary))
+        {
+            return;
+        }
+
         context.ReportDiagnostic(
             Diagnostic.Create(DiagnosticDescriptors.ThrowIfNull, binary.GetLocation(), argument.ToString())
         );
+    }
+
+    /// <summary>
+    /// Determines whether hoisting an <c>ArgumentNullException.ThrowIfNull</c> call from
+    /// <paramref name="coalesce"/> to its nearest enclosing <see cref="StatementSyntax"/> would change program
+    /// behavior, either because it would move the code out of an anonymous function or local function (changing
+    /// when it executes), out of an expression-bodied member (escaping the member entirely), or out of a
+    /// conditionally-evaluated subtree, such as a ternary branch or the right-hand side of <c>??</c>, <c>&amp;&amp;</c>,
+    /// or <c>||</c> (changing whether it executes at all).
+    /// </summary>
+    /// <param name="coalesce">The coalesce expression under analysis.</param>
+    /// <returns><see langword="true"/> if hoisting would change semantics; otherwise, <see langword="false"/>.</returns>
+    private static bool IsConditionallyEvaluatedRelativeToContainingStatement(BinaryExpressionSyntax coalesce)
+    {
+        SyntaxNode? previous = coalesce;
+
+        for (var current = coalesce.Parent; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case AnonymousFunctionExpressionSyntax:
+                case LocalFunctionStatementSyntax:
+                case ArrowExpressionClauseSyntax:
+                    return true;
+                case ConditionalExpressionSyntax conditional
+                    when previous == conditional.WhenTrue || previous == conditional.WhenFalse:
+                    return true;
+                case BinaryExpressionSyntax binary
+                    when previous == binary.Right
+                        && (
+                            binary.IsKind(SyntaxKind.CoalesceExpression)
+                            || binary.IsKind(SyntaxKind.LogicalAndExpression)
+                            || binary.IsKind(SyntaxKind.LogicalOrExpression)
+                        ):
+                    return true;
+                case StatementSyntax:
+                    // Reached the containing statement without crossing a boundary that would change behavior.
+                    return false;
+            }
+
+            previous = current;
+        }
+
+        return false;
     }
 
     /// <summary>Analyzes an <c>if</c> statement and reports NEA0001 when it is a null-check-then-throw of <see cref="ArgumentNullException"/>.</summary>

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -428,6 +428,213 @@ public sealed class ThrowIfNullAnalyzerTests
     }
 
     [Test]
+    public async Task Analyze_WhenCoalesceInAnonymousMethodStatement_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    Action<string> f = delegate(string s)
+                    {
+                        _ = s ?? throw new ArgumentNullException(nameof(s));
+                    };
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0001");
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceInExpressionBodiedProperty_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private readonly string? _a;
+
+                public string P => _a ?? throw new ArgumentNullException(nameof(_a));
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceInConditionalExpressionWhenFalseBranch_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(bool flag, string? a)
+                {
+                    var x = flag ? "d" : (a ?? throw new ArgumentNullException(nameof(a)));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceIsConditionOfTernary_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(bool? b)
+                {
+                    var x = (b ?? throw new ArgumentNullException(nameof(b))) ? "y" : "n";
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0001");
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceIsRightOperandOfEnclosingCoalesce_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? a, string? b)
+                {
+                    var x = a ?? (b ?? throw new ArgumentNullException(nameof(b)));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceIsRightOperandOfLogicalAnd_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(bool flag, bool? b)
+                {
+                    _ = flag && (b ?? throw new ArgumentNullException(nameof(b)));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceIsRightOperandOfLogicalOr_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(bool flag, bool? b)
+                {
+                    _ = flag || (b ?? throw new ArgumentNullException(nameof(b)));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceIsLeftOperandOfLogicalAnd_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(bool flag, bool? b)
+                {
+                    _ = (b ?? throw new ArgumentNullException(nameof(b))) && flag;
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0001");
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceIsLeftOperandOfLogicalOr_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(bool flag, bool? b)
+                {
+                    _ = (b ?? throw new ArgumentNullException(nameof(b))) || flag;
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0001");
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceIsLeftOperandOfEnclosingCoalesce_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? a)
+                {
+                    var x = (a ?? throw new ArgumentNullException(nameof(a))) ?? "d";
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0001");
+    }
+
+    [Test]
     public async Task CodeFix_WhenCoalesceIsNestedInsideIfStatement_HoistsThrowIfNullAndKeepsAssignment()
     {
         const string source = """

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -344,6 +344,90 @@ public sealed class ThrowIfNullAnalyzerTests
     }
 
     [Test]
+    public async Task Analyze_WhenCoalesceInSimpleLambdaParameterExpression_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    Func<string, string> f = s => s ?? throw new ArgumentNullException(nameof(s));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceInParenthesizedLambdaCapturingOuterVariable_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? a)
+                {
+                    Func<string> f = () => a ?? throw new ArgumentNullException(nameof(a));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceInsideConditionalExpressionBranch_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(bool flag, string? a)
+                {
+                    var x = flag ? (a ?? throw new ArgumentNullException(nameof(a))) : "d";
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCoalesceInStatementBodiedLambda_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M()
+                {
+                    Action<string> f = s =>
+                    {
+                        _ = s ?? throw new ArgumentNullException(nameof(s));
+                    };
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0001");
+    }
+
+    [Test]
     public async Task CodeFix_WhenCoalesceIsNestedInsideIfStatement_HoistsThrowIfNullAndKeepsAssignment()
     {
         const string source = """


### PR DESCRIPTION
## Defect

`ThrowIfNullCodeFixProvider.cs:117` anchors the coalesce fix on `coalesce.FirstAncestorOrSelf<StatementSyntax>()`, then unconditionally hoists `ArgumentNullException.ThrowIfNull(arg);` before that statement and replaces the coalesce with the bare operand. That anchor walks straight out of anonymous functions/local functions and straight through `ConditionalExpressionSyntax` branches — but the analyzer (`ThrowIfNullAnalyzer.cs`, rule NEA0001) only checked that *some* enclosing statement exists, so it reported (and offered a fix for) shapes where the fix is unsafe or does not compile.

### Before / after examples

**Does not compile after fix (CS0103):**
```csharp
// before
Func<string, string> f = s => s ?? throw new ArgumentNullException(nameof(s));

// after (old behavior) - "s" is not in scope at the hoisted position
ArgumentNullException.ThrowIfNull(s);
Func<string, string> f = s => s;
```

**Silent eager throw (lambda capture):**
```csharp
// before
Func<string> f = () => a ?? throw new ArgumentNullException(nameof(a));

// after (old behavior) - check moves from invocation time to declaration time
ArgumentNullException.ThrowIfNull(a);
Func<string> f = () => a;
```

**Silent eager throw (conditional expression):**
```csharp
// before
var x = flag ? (a ?? throw new ArgumentNullException(nameof(a))) : "d";

// after (old behavior) - now throws even when flag is false
ArgumentNullException.ThrowIfNull(a);
var x = flag ? a : "d";
```

Statement-bodied lambdas are unaffected — their coalesce already has a containing statement inside the lambda's own block, so hoisting stays within the lambda and is safe.

## Fix

The fix is entirely in the analyzer (`src/NetEvolve.Arguments.Analyser/ThrowIfNullAnalyzer.cs`), so the diagnostic is never reported for these shapes and no fix is ever offered:

Added `IsConditionallyEvaluatedRelativeToContainingStatement`, a purely syntactic walk (no semantic model needed) from the coalesce expression up to its nearest enclosing `StatementSyntax`. It bails out (returns `true`, suppressing the diagnostic) when the walk crosses:

- an `AnonymousFunctionExpressionSyntax` (covers simple lambdas, parenthesized lambdas, and anonymous methods),
- a `LocalFunctionStatementSyntax`,
- an `ArrowExpressionClauseSyntax` (expression-bodied members — walking to a `StatementSyntax` from inside one would escape the member entirely),
- a `ConditionalExpressionSyntax`'s `WhenTrue`/`WhenFalse` branch, or
- the conditionally-evaluated `Right` side of an enclosing `??`, `&&`, or `||` expression.

`ThrowIfNullCodeFixProvider.cs` itself was intentionally left untouched — it is owned by another change in this defect-fixing effort (dispatch bug, leading-trivia duplication, and the `InsertBefore` assumption are separate, unrelated findings).

## Tests added (`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs`)

Negative regression tests (must NOT report NEA0001):
- `Analyze_WhenCoalesceInSimpleLambdaParameterExpression_DoesNotReportDiagnostic` — `s => s ?? throw new ArgumentNullException(nameof(s));`
- `Analyze_WhenCoalesceInParenthesizedLambdaCapturingOuterVariable_DoesNotReportDiagnostic` — `() => a ?? throw new ArgumentNullException(nameof(a));`
- `Analyze_WhenCoalesceInsideConditionalExpressionBranch_DoesNotReportDiagnostic` — `flag ? (a ?? throw new ArgumentNullException(nameof(a))) : "d";`

Positive test proving the fix is not over-broad (statement-bodied lambda still reports):
- `Analyze_WhenCoalesceInStatementBodiedLambda_ReportsDiagnostic`

## Verification

- Confirmed the three negative tests fail (report a diagnostic) against the pre-fix analyzer, and pass after the fix.
- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings, 0 errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 107/107 passed.
