### PR TITLE
perf(analyser): reorder NEA0005 checks to run syntax gate before semantic lookup

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfDisposedAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfDisposedAnalyzer.cs
@@ -54,6 +54,19 @@ public sealed class ThrowIfDisposedAnalyzer : DiagnosticAnalyzer
     {
         var ifStatement = (IfStatementSyntax)context.Node;
 
+        if (
+            !SyntaxHelpers.TryGetThrownException(
+                ifStatement,
+                context.SemanticModel,
+                ObjectDisposedExceptionMetadataName,
+                context.CancellationToken,
+                out _
+            )
+        )
+        {
+            return;
+        }
+
         var enclosingSymbol = context.SemanticModel.GetEnclosingSymbol(
             ifStatement.SpanStart,
             context.CancellationToken
@@ -83,19 +96,6 @@ public sealed class ThrowIfDisposedAnalyzer : DiagnosticAnalyzer
             }
 
             symbol = symbol.ContainingSymbol;
-        }
-
-        if (
-            !SyntaxHelpers.TryGetThrownException(
-                ifStatement,
-                context.SemanticModel,
-                ObjectDisposedExceptionMetadataName,
-                context.CancellationToken,
-                out _
-            )
-        )
-        {
-            return;
         }
 
         context.ReportDiagnostic(


### PR DESCRIPTION
**Expected conflict note:** Two other agents are concurrently touching `ThrowIfDisposedAnalyzer.cs` in this same file — one fixing the nested-static-scope guard (~line 62), another adding constructor-argument validation (~line 73). This PR is a pure line reordering within the `Analyze` method and should rebase cleanly against either.

## Defect (severity LOW — the only performance finding in the review)

`ThrowIfDisposedAnalyzer.cs:57` called `context.SemanticModel.GetEnclosingSymbol(...)` as the first action in the per-`if`-statement callback, before the pure-syntax rejections inside `SyntaxHelpers.TryGetThrownException` (which rejects on an `else` clause, on a non-single-throw body, and on a non-object-creation throw). Every sibling analyzer in this package runs its syntax matcher first and only touches the semantic model afterward — this rule was the exception.

## Fix

Hoisted the `SyntaxHelpers.TryGetThrownException(...)` call above the `GetEnclosingSymbol`/`IsStatic` check, so the cheap syntactic rejections run first and the semantic call only happens for `if` statements that already match the required shape. Both predicates are pure and side-effect-free, so this is semantics-preserving — verified by the full existing NEA0005 test suite passing unchanged (no new test added, since this is a pure reorder with no behavior change).

## Honest impact assessment — do not oversell

- The syntax-node action for this rule is only registered on pre-.NET-7 compilations; NEA0005 self-disables via a `HasBuiltInMember` gate whenever the BCL exposes `ObjectDisposedException.ThrowIf`. Modern projects targeting .NET 7+ never execute this path at all.
- Roslyn's per-tree `SemanticModel`/`MemberSemanticModel` caching amortizes `GetEnclosingSymbol` to roughly one member-model construction per enclosing member — not one bind per `if` statement — so the original ordering was not paying a bind cost per statement either.
- The analyzer is shaped this way for a legitimate reason: it is the only rule in the package with a real semantic precondition (instance vs. static member), because its fix emits `this`.

This is a genuine but minor consistency/ordering improvement, not a measured performance win. No benchmark was run and none is claimed.

## Package audit

Audited the rest of `NetEvolve.Arguments.Analyser` for similar hot-path issues: every analyzer registers a single narrow `SyntaxKind.IfStatement` action, all call `EnableConcurrentExecution()` and `ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)`, descriptors are `static readonly`, and no caching change is warranted anywhere else in the package.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeded, 0 warnings, 0 errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 103/103 passed.
