### PR TITLE
fix(analyser): require side-effect-free operand in combined-range check

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeAnalyzer.cs
@@ -174,12 +174,39 @@ public sealed class ThrowIfOutOfRangeAnalyzer : DiagnosticAnalyzer
         var lessThanValue = SyntaxHelpers.Unwrap(lessThan.Left);
         var greaterThanValue = SyntaxHelpers.Unwrap(greaterThan.Left);
 
-        if (lessThanValue is LiteralExpressionSyntax || !SyntaxHelpers.AreEquivalent(lessThanValue, greaterThanValue))
+        if (!IsSideEffectFreeOperand(lessThanValue) || !SyntaxHelpers.AreEquivalent(lessThanValue, greaterThanValue))
         {
             return false;
         }
 
         comparison = new ComparisonResult("ThrowIfOutOfRange", lessThanValue, lessThan.Right, greaterThan.Right);
         return true;
+    }
+
+    /// <summary>
+    /// Determines whether an expression is safe to fold from two source occurrences (once on each side of the
+    /// combined-range condition) into a single occurrence in the generated throw-helper call. The combined-range
+    /// shape is the only one where the operand is textually duplicated in the source but emitted only once in the
+    /// fix, so unlike the simple comparison shapes, evaluating it twice versus once can silently change behavior if
+    /// the expression has a side effect (e.g. it advances an iterator or increments a counter).
+    /// </summary>
+    /// <remarks>
+    /// This is a conservative, purely syntactic allow-list: a bare identifier (a parameter or local), or a chain of
+    /// member accesses rooted in one. Invocations, indexers, object creation, <c>await</c>, and assignment or
+    /// increment/decrement expressions are all rejected. Note that a member access is not strictly guaranteed to be
+    /// side-effect-free either, since a property getter can run arbitrary code; however, rejecting all member access
+    /// would gut the rule's main use case (e.g. <c>arg.Length</c>), so accepting member-access chains while
+    /// rejecting invocations is the pragmatic line drawn here.
+    /// </remarks>
+    /// <param name="expression">The already-unwrapped operand expression to test.</param>
+    /// <returns><see langword="true"/> if <paramref name="expression"/> is an identifier or a member-access chain rooted in one; otherwise, <see langword="false"/>.</returns>
+    private static bool IsSideEffectFreeOperand(ExpressionSyntax expression)
+    {
+        while (expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            expression = SyntaxHelpers.Unwrap(memberAccess.Expression);
+        }
+
+        return expression is IdentifierNameSyntax;
     }
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
@@ -211,6 +211,79 @@ public sealed class ThrowIfOutOfRangeAnalyzerTests
     }
 
     [Test]
+    public async Task Analyze_WhenCombinedRangeOperandIsInvocation_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                int Next() => 0;
+
+                void M()
+                {
+                    if (Next() < 5 || Next() > 100) throw new ArgumentOutOfRangeException("x");
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCombinedRangeOperandIsElementAccess_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(int[] items)
+                {
+                    if (items[0] < 5 || items[0] > 100) throw new ArgumentOutOfRangeException("x");
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenCombinedRangeOperandIsMemberAccess_ReportsDiagnosticAndFixes()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string argument)
+                {
+                    if (argument.Length < 5 || argument.Length > 100) throw new ArgumentOutOfRangeException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfOutOfRangeAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0003");
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfOutOfRangeAnalyzer(),
+            new ThrowIfOutOfRangeCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert
+            .That(fixedSource)
+            .Contains("ArgumentOutOfRangeException.ThrowIfOutOfRange(argument.Length, 5, 100);");
+    }
+
+    [Test]
     [Arguments("bool argument", "argument")]
     [Arguments("int argument, int other", "argument < 5 || other > 100")]
     [Arguments("int argument", "argument > 100 || argument < 5")]


### PR DESCRIPTION
**EXPECTED CONFLICT**: Two other agents are concurrently editing `ThrowIfOutOfRangeAnalyzer.cs` in the same file region (IEquatable/IComparable operand gating, and floating-point NaN exclusion). This PR touches a different, non-overlapping part of the same file (the combined-range operand-identity check, lines ~174-182). The repository owner has accepted this — one PR per finding, conflicts to be resolved at merge time.

## Defect

For the combined-range shape (`value < min || value > max`), `ThrowIfOutOfRangeAnalyzer.cs` established that both sides target "the same value" using `SyntaxHelpers.AreEquivalent`, a purely *textual* comparison. The only operand it rejected was a literal. Any other syntactically-identical expression — including one with side effects — was accepted, and the fix folds the two source occurrences into a single evaluation.

### Before / after

```csharp
// Before: analyzer reports NEA0003, fix silently changes evaluation count
if (Next() < 5 || Next() > 100) throw new ArgumentOutOfRangeException("x");
// →
ArgumentOutOfRangeException.ThrowIfOutOfRange(Next(), 5, 100);
```

If `Next()` advances an iterator, increments a counter, or reads a stream, the rewritten code behaves differently from the original — the original may call it up to twice (short-circuited to once when the first comparison is true), the fix always calls it exactly once. This is a silent, wrong fix.

Note: a separate, independent change is replacing `SyntaxHelpers.AreEquivalent`'s `ToString()` comparison with `SyntaxFactory.AreEquivalent`. That does not fix this defect — two identical invocation expressions remain syntactically equivalent either way. This PR is independent of that change.

## Fix

`ThrowIfOutOfRangeAnalyzer.TryGetCombinedRangeComparison` now requires the combined-range operand to pass a new `IsSideEffectFreeOperand` check before reporting, in addition to the existing textual-equivalence check. The check is a conservative, purely syntactic allow-list:

- an `IdentifierNameSyntax` (a parameter or local), or
- a `MemberAccessExpressionSyntax` chain whose root is an identifier (e.g. `options.Name.Length`)

Everything else is rejected — in particular `InvocationExpressionSyntax`, `ElementAccessExpressionSyntax` (indexers can have side effects), object creation, `await`, and assignment/increment/decrement expressions.

**Trade-off, stated explicitly**: property access is not strictly guaranteed to be side-effect-free either — a getter can run arbitrary code. Rejecting all member access, however, would gut the rule's main real-world use case (`arg.Length`, `arg.Count`). Accepting member-access chains while rejecting invocations/indexers is the pragmatic line drawn here; it does not eliminate every theoretical risk, but it removes the common, concrete cases (calls and indexers) while keeping the rule useful.

This is scoped to the combined-range path only. The simple single-comparison paths (`value < min`, `value == 0`, etc.) evaluate their operand once in the original source and once in the fix, so they don't have this duplication problem and are left untouched.

## Test added

`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs`:
- `Analyze_WhenCombinedRangeOperandIsInvocation_DoesNotReportDiagnostic` — `Next() < 5 || Next() > 100` must not report (regression for the defect).
- `Analyze_WhenCombinedRangeOperandIsElementAccess_DoesNotReportDiagnostic` — `items[0] < 5 || items[0] > 100` must not report.
- `Analyze_WhenCombinedRangeOperandIsMemberAccess_ReportsDiagnosticAndFixes` — `argument.Length < 5 || argument.Length > 100` must still report and fix to `ThrowIfOutOfRange(argument.Length, 5, 100)`, confirming the member-access use case still works.

Confirmed the two new negative tests fail (diagnostic incorrectly reported) against the pre-fix code, and pass after the fix.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeded, 0 warnings, 0 errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 106/106 passed.
