### PR TITLE
fix(analyser): compare expressions structurally instead of by ToString()

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/SyntaxHelpers.cs
+++ b/src/NetEvolve.Arguments.Analyser/SyntaxHelpers.cs
@@ -396,5 +396,5 @@ internal static class SyntaxHelpers
     /// <param name="right">The second expression.</param>
     /// <returns><see langword="true"/> if both expressions render to the same source text; otherwise, <see langword="false"/>.</returns>
     public static bool AreEquivalent(ExpressionSyntax left, ExpressionSyntax right) =>
-        left.ToString() == right.ToString();
+        Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AreEquivalent(left, right, topLevel: false);
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfLengthAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfLengthAnalyzerTests.cs
@@ -38,6 +38,33 @@ public sealed class ThrowIfLengthAnalyzerTests
     }
 
     [Test]
+    public async Task Analyze_WhenCombinedRangeTargetsHaveInteriorTrivia_ReportsDiagnostic()
+    {
+        var source = """
+            using System;
+
+            class Options
+            {
+                public string Name { get; set; } = string.Empty;
+            }
+
+            class C
+            {
+                void M(Options options)
+                {
+                    if (options.Name.Length < 1 || options /*x*/ .Name.Length > 10)
+                        throw new ArgumentException(nameof(options));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfLengthAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0006");
+    }
+
+    [Test]
     [Arguments("if (argument.Length > 100) throw new ArgumentOutOfRangeException(nameof(argument));")]
     [Arguments("if (argument.Count > 100) throw new ArgumentException(nameof(argument));")]
     [Arguments("if (argument.Length == 100) throw new ArgumentException(nameof(argument));")]


### PR DESCRIPTION
## Defect

`SyntaxHelpers.AreEquivalent` (used by `AreSameReference` and directly by `ThrowIfCountAnalyzer`, `ThrowIfLengthAnalyzer`, and `ThrowIfOutOfRangeAnalyzer` to check that both sides of a combined-range comparison, or a `nameof(...)` argument, target the same expression) compared expressions with:

```csharp
public static bool AreEquivalent(ExpressionSyntax left, ExpressionSyntax right) =>
    left.ToString() == right.ToString();
```

`SyntaxNode.ToString()` strips only the node's *own* leading/trailing trivia but preserves trivia at internal token boundaries. Two syntactically identical targets separated by an interior comment (or other non-adjacent trivia) therefore render to different text and compare unequal, causing the corresponding diagnostic to be silently *not* reported (false negative).

### Before

```csharp
if (options.Name.Length < 1 || options /*x*/ .Name.Length > 10)
    throw new ArgumentException(nameof(options));
```

`target1.ToString()` is `"options.Name"`, `target2.ToString()` is `"options /*x*/ .Name"` — unequal, so NEA0006 is not reported even though both targets are the same expression.

### After

Both render as equivalent via structural (trivia-insensitive) comparison, so NEA0006 fires and the fix collapses the condition into `ArgumentException.ThrowIfLengthOutOfRange(options.Name, 1, 10);`.

## Fix

Replaced the `ToString()` comparison with:

```csharp
public static bool AreEquivalent(ExpressionSyntax left, ExpressionSyntax right) =>
    Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AreEquivalent(left, right, topLevel: false);
```

The call is fully qualified. `Microsoft.CodeAnalysis.CSharp` is already `using`-imported in this file, so an unqualified `AreEquivalent(left, right)` call would bind back to this very method and recurse infinitely.

This is a narrow, low-severity fix: a single-identifier target has no interior trivia and was never affected, and trailing trivia (e.g. a line break before a member-access continuation) was also never affected — only interior trivia between tokens of the same target expression.

## Known separate issue (not fixed here, out of scope)

`ThrowIfOutOfRangeAnalyzer.cs:174-177` rejects only literal bounds, so a combined range like `if (Next() < 5 || Next() > 100) throw ...` treats two separate evaluations of a side-effecting call as the same value and the code fix collapses them into a single `ThrowIfOutOfRange(Next(), 5, 100)` call, dropping one evaluation. `SyntaxFactory.AreEquivalent` does not help here — two identical invocation expressions ARE syntactically equivalent regardless of side effects, so this change neither fixes nor worsens that separate defect. It would need an additional check that the target is side-effect-free (an identifier or member-access chain over parameters/locals) before treating repeated invocations as the same value.

## Test added

`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfLengthAnalyzerTests.cs`:
`Analyze_WhenCombinedRangeTargetsHaveInteriorTrivia_ReportsDiagnostic` — asserts NEA0006 is now reported for a combined-range check whose two targets are separated by an interior block comment.

## Verification

- Confirmed the new test fails on the pre-fix code (`Expected to have count equal to 1 but received 0`) and passes after the fix.
- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings/errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — full suite green: 104 total, 0 failed (includes existing NEA0003/NEA0006/NEA0007 coverage, so no regressions from the shared helper change).
