### PR TITLE
fix(analyser): stop duplicating leading trivia in coalesce code fix

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
@@ -135,6 +135,10 @@ public sealed class ThrowIfNullCodeFixProvider : CodeFixProvider
 
         editor.InsertBefore(containingStatement, throwIfNullStatement);
         editor.ReplaceNode(coalesce, argument.WithoutTrivia());
+        editor.ReplaceNode(
+            containingStatement,
+            (currentNode, _) => currentNode.WithLeadingTrivia(SyntaxFactory.ElasticMarker)
+        );
 
         return editor.GetChangedDocument();
     }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -1,5 +1,7 @@
 namespace NetEvolve.Arguments.Analyser.Tests.Unit;
 
+using System;
+
 public sealed class ThrowIfNullAnalyzerTests
 {
     [Test]
@@ -126,6 +128,85 @@ public sealed class ThrowIfNullAnalyzerTests
         _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
         _ = await Assert.That(fixedSource).Contains("_value = argument;");
         _ = await Assert.That(fixedSource).DoesNotContain("throw new ArgumentNullException");
+    }
+
+    [Test]
+    public async Task CodeFix_WhenAppliedToCoalesceWithRegionTrivia_DoesNotDuplicateLeadingTrivia()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private readonly string _value;
+
+                public C(string? argument)
+                {
+                    #region Guards
+                    _value = argument ?? throw new ArgumentNullException(nameof(argument));
+                    #endregion
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        var regionOccurrences = CountOccurrences(fixedSource, "#region Guards");
+        var endRegionOccurrences = CountOccurrences(fixedSource, "#endregion");
+
+        _ = await Assert.That(regionOccurrences).IsEqualTo(1);
+        _ = await Assert.That(endRegionOccurrences).IsEqualTo(1);
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(fixedSource).Contains("_value = argument;");
+    }
+
+    [Test]
+    public async Task CodeFix_WhenAppliedToCoalesceWithLeadingComment_DoesNotDuplicateComment()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private readonly string _value;
+
+                public C(string? argument)
+                {
+                    // validate input
+                    _value = argument ?? throw new ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        var commentOccurrences = CountOccurrences(fixedSource, "// validate input");
+
+        _ = await Assert.That(commentOccurrences).IsEqualTo(1);
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(fixedSource).Contains("_value = argument;");
+    }
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var index = 0;
+
+        while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
     }
 
     [Test]


### PR DESCRIPTION
## Defect

`ThrowIfNullCodeFixProvider.ApplyCoalesceFixAsync` rewrites `arg ?? throw new ArgumentNullException(nameof(arg))` by inserting a new `ArgumentNullException.ThrowIfNull(arg);` statement before the statement that contains the coalesce expression. It copied the containing statement's leading trivia onto the newly inserted statement, but never removed that trivia from the original statement — so every comment or preprocessor directive in the leading trivia was emitted twice.

### Before

```csharp
public C(string? argument)
{
    #region Guards
    _value = argument ?? throw new ArgumentNullException(nameof(argument));
    #endregion
}
```

Applying the code fix produced:

```csharp
public C(string? argument)
{
    #region Guards
    #region Guards
    ArgumentNullException.ThrowIfNull(argument);
    _value = argument;
    #endregion
}
```

Two `#region` directives against one `#endregion` is **CS1038 "#endregion directive expected"** — the fix produced non-compiling source. A leading `// comment` above the statement was likewise duplicated.

### After

```csharp
public C(string? argument)
{
    #region Guards
    ArgumentNullException.ThrowIfNull(argument);
    _value = argument;
    #endregion
}
```

### Fix

In `src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs`, the inserted `ArgumentNullException.ThrowIfNull(...)` statement keeps the containing statement's original leading trivia (unchanged), and the containing statement itself is now replaced with a copy whose leading trivia is stripped down to `SyntaxFactory.ElasticMarker` via a second `DocumentEditor.ReplaceNode` call:

```csharp
editor.InsertBefore(containingStatement, throwIfNullStatement);
editor.ReplaceNode(coalesce, argument.WithoutTrivia());
editor.ReplaceNode(
    containingStatement,
    (currentNode, _) => currentNode.WithLeadingTrivia(SyntaxFactory.ElasticMarker)
);
```

The delegate form of `ReplaceNode` is used (rather than passing a precomputed replacement node) so this edit composes correctly with the existing `ReplaceNode(coalesce, ...)` edit against a descendant of `containingStatement` — `DocumentEditor` re-resolves the current state of the node before applying each edit.

## Tests added

In `tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs`:
- `CodeFix_WhenAppliedToCoalesceWithRegionTrivia_DoesNotDuplicateLeadingTrivia` — reproduces the `#region`/`#endregion` case and asserts the fixed source contains exactly one `#region Guards` and exactly one `#endregion`.
- `CodeFix_WhenAppliedToCoalesceWithLeadingComment_DoesNotDuplicateComment` — reproduces a leading `// validate input` comment and asserts it appears exactly once in the fixed source.

Both assertions count occurrences via a small `CountOccurrences` helper since the harness's existing fix assertions are `Contains`-based and can't express "exactly once."

## Verification

- Confirmed both new tests **fail** against the pre-fix code (occurrence count of 2 for both the region and the comment case) by temporarily reverting the fix and re-running the suite.
- Confirmed both tests **pass** after the fix, and dumped the actual fixed source for the `#region` case to visually verify correct formatting (no merged lines, no duplicated trivia, correct indentation):
  ```csharp
  public C(string? argument)
  {
      #region Guards
      ArgumentNullException.ThrowIfNull(argument);
      _value = argument;
      #endregion
  }
  ```
- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings, 0 errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 105/105 passing.

## Out of scope

The following related findings in the same code fix provider are tracked and being fixed separately, and are intentionally not touched here:
- the coalesce-vs-if dispatch bug
- hoisting the fix out of lambdas / ternaries (analyzer-side gate)
- the embedded-statement / `InsertBefore` list assumption
- unqualified exception names / missing `using System;` in generated code
- dropped comments in the replaced `if` block
