### PR TITLE
fix(analyser): insert using System when code fix emits polyfill receiver

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceCodeFixProvider.cs
@@ -97,6 +97,11 @@ public sealed class ThrowIfContainsWhiteSpaceCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfCountCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfCountCodeFixProvider.cs
@@ -105,6 +105,11 @@ public sealed class ThrowIfCountCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfDefaultCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfDefaultCodeFixProvider.cs
@@ -94,6 +94,11 @@ public sealed class ThrowIfDefaultCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfDisposedCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfDisposedCodeFixProvider.cs
@@ -96,6 +96,11 @@ public sealed class ThrowIfDisposedCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidCodeFixProvider.cs
@@ -94,6 +94,11 @@ public sealed class ThrowIfEmptyGuidCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfLengthCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfLengthCodeFixProvider.cs
@@ -105,6 +105,11 @@ public sealed class ThrowIfLengthCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
@@ -95,6 +95,11 @@ public sealed class ThrowIfNullCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, throwIfNullInvocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 
@@ -136,7 +141,15 @@ public sealed class ThrowIfNullCodeFixProvider : CodeFixProvider
         editor.InsertBefore(containingStatement, throwIfNullStatement);
         editor.ReplaceNode(coalesce, argument.WithoutTrivia());
 
-        return editor.GetChangedDocument();
+        var changedDocument = editor.GetChangedDocument();
+        var changedRoot = await changedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (changedRoot is CompilationUnitSyntax compilationUnit)
+        {
+            return changedDocument.WithSyntaxRoot(UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit));
+        }
+
+        return changedDocument;
     }
 
     /// <summary>Builds the <c>ArgumentNullException.ThrowIfNull(argument)</c> invocation expression used by both fix paths.</summary>

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullOrEmptyCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullOrEmptyCodeFixProvider.cs
@@ -99,6 +99,11 @@ public sealed class ThrowIfNullOrEmptyCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeCodeFixProvider.cs
@@ -116,6 +116,11 @@ public sealed class ThrowIfOutOfRangeCodeFixProvider : CodeFixProvider
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);
 
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = UsingDirectiveInserter.EnsureSystemUsingDirective(compilationUnit);
+        }
+
         return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/NetEvolve.Arguments.Analyser/UsingDirectiveInserter.cs
+++ b/src/NetEvolve.Arguments.Analyser/UsingDirectiveInserter.cs
@@ -1,0 +1,72 @@
+namespace NetEvolve.Arguments.Analyser;
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+/// <summary>
+/// Ensures the <c>using System;</c> directive required to resolve the <c>System</c> throw-helper
+/// extension members is present in a fixed document. The code fix providers in this project emit
+/// unqualified receivers (e.g. <c>ArgumentNullException.ThrowIfNull(...)</c>); on frameworks where the
+/// call binds to the polyfilled extension members in <c>NetEvolve.Arguments</c>, the extension block
+/// lives in namespace <c>System</c>, so the containing namespace must be imported for the call to
+/// resolve, even though the diagnostic itself can fire on a fully-qualified throw expression that
+/// required no such <c>using</c> directive.
+/// </summary>
+internal static class UsingDirectiveInserter
+{
+    private const string RequiredNamespace = "System";
+
+    /// <summary>
+    /// Inserts a <c>using System;</c> directive into <paramref name="root"/> unless one is already present,
+    /// respecting whether the file uses a file-scoped or block-scoped namespace declaration (or none at all).
+    /// </summary>
+    /// <param name="root">The compilation unit to update.</param>
+    /// <returns>The compilation unit with a <c>using System;</c> directive present.</returns>
+    internal static CompilationUnitSyntax EnsureSystemUsingDirective(CompilationUnitSyntax root)
+    {
+        if (HasSystemUsing(root.Usings))
+        {
+            return root;
+        }
+
+        if (root.Members.Count == 1 && root.Members[0] is FileScopedNamespaceDeclarationSyntax fileScopedNamespace)
+        {
+            if (HasSystemUsing(fileScopedNamespace.Usings))
+            {
+                return root;
+            }
+
+            var updatedNamespace = fileScopedNamespace.WithUsings(
+                fileScopedNamespace.Usings.Add(CreateSystemUsingDirective())
+            );
+
+            return root.WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(updatedNamespace));
+        }
+
+        if (root.Members.Count == 1 && root.Members[0] is NamespaceDeclarationSyntax blockNamespace)
+        {
+            if (HasSystemUsing(blockNamespace.Usings))
+            {
+                return root;
+            }
+
+            var updatedNamespace = blockNamespace.WithUsings(blockNamespace.Usings.Add(CreateSystemUsingDirective()));
+
+            return root.WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(updatedNamespace));
+        }
+
+        return root.WithUsings(root.Usings.Add(CreateSystemUsingDirective()));
+    }
+
+    private static bool HasSystemUsing(SyntaxList<UsingDirectiveSyntax> usings) =>
+        usings.Any(usingDirective =>
+            usingDirective.Alias is null && usingDirective.Name?.ToString() == RequiredNamespace
+        );
+
+    private static UsingDirectiveSyntax CreateSystemUsingDirective() =>
+        SyntaxFactory
+            .UsingDirective(SyntaxFactory.IdentifierName(RequiredNamespace))
+            .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+}

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -310,4 +310,138 @@ public sealed class ThrowIfNullAnalyzerTests
         _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
         _ = await Assert.That(fixedSource).DoesNotContain("throw new");
     }
+
+    [Test]
+    public async Task CodeFix_WhenFileScopedNamespaceHasNoUsingSystem_AddsUsingSystemDirective()
+    {
+        const string source = """
+            namespace Test;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    if (argument is null) throw new System.ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("using System;");
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(fixedSource.Split("using System;").Length).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CodeFix_WhenFileScopedNamespaceAlreadyHasUsingSystem_DoesNotDuplicateDirective()
+    {
+        const string source = """
+            namespace Test;
+
+            using System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    if (argument is null) throw new System.ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(fixedSource.Split("using System;").Length).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CodeFix_WhenBlockScopedNamespaceHasNoUsingSystem_AddsUsingSystemDirective()
+    {
+        const string source = """
+            namespace Test
+            {
+                class C
+                {
+                    void M(string? argument)
+                    {
+                        if (argument is null) throw new System.ArgumentNullException(nameof(argument));
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("using System;");
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(fixedSource.Split("using System;").Length).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CodeFix_WhenBlockScopedNamespaceAlreadyHasUsingSystem_DoesNotDuplicateDirective()
+    {
+        const string source = """
+            namespace Test
+            {
+                using System;
+
+                class C
+                {
+                    void M(string? argument)
+                    {
+                        if (argument is null) throw new System.ArgumentNullException(nameof(argument));
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(fixedSource.Split("using System;").Length).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CodeFix_WhenSourceHasOnlyAliasedSystemUsing_AddsRealUsingSystemDirective()
+    {
+        const string source = """
+            using SysArg = System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    if (argument is null) throw new System.ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("using SysArg = System;");
+        _ = await Assert.That(fixedSource).Contains("using System;");
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+    }
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -286,4 +286,28 @@ public sealed class ThrowIfNullAnalyzerTests
         _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
         _ = await Assert.That(fixedSource).DoesNotContain("throw new ArgumentNullException");
     }
+
+    [Test]
+    public async Task CodeFix_WhenSourceHasNoUsingSystemAndThrowIsFullyQualified_AddsUsingSystemDirective()
+    {
+        const string source = """
+            class C
+            {
+                void M(string? argument)
+                {
+                    if (argument is null) throw new System.ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("using System;");
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(fixedSource).DoesNotContain("throw new");
+    }
 }


### PR DESCRIPTION
**Expected conflict:** this PR touches all nine code fix providers, including `ThrowIfNullCodeFixProvider.cs` and `ThrowIfDisposedCodeFixProvider.cs`, which other agents are concurrently editing for separate findings in this batch. The repository owner has accepted this — one PR per finding.

## Defect

Every code fix provider in `src/NetEvolve.Arguments.Analyser` builds the throw-helper receiver as a bare `SyntaxFactory.IdentifierName("<ExceptionType>")` (e.g. `ArgumentNullException`), and none of them ensure the corresponding `using` directive is present in the fixed document.

`SyntaxHelpers.IsExceptionType` (`SyntaxHelpers.cs:69-80`) resolves the thrown type semantically via the `SemanticModel`, so it is qualification-insensitive: a file with no `using System;` that throws the *fully qualified* exception is still diagnosed and "fixed".

Before (no `using System;`):
```csharp
namespace X;

public class C
{
    public void M(string? s)
    {
        if (s is null) throw new System.ArgumentNullException(nameof(s));
    }
}
```

The fix previously emitted:
```csharp
namespace X;

public class C
{
    public void M(string? s)
    {
        ArgumentNullException.ThrowIfNull(s);
    }
}
```
which fails with **CS0103** ("ArgumentNullException" does not exist in the current context).

Simply qualifying the receiver (`System.ArgumentNullException.ThrowIfNull(...)`) is **not** sufficient either: on frameworks where the BCL throw-helper doesn't exist yet, the call must bind to the `NetEvolve.Arguments` polyfill, which is a C# `extension(ArgumentNullException)` block declared in `namespace System` (see `src/NetEvolve.Arguments/ArgumentNullExceptionPolyfills.cs` and the sibling `ArgumentExceptionPolyfill.cs`, `ArgumentOutOfRangeExceptionPolyfills.cs`, `ObjectDisposedExceptionPolyfills.cs` — all declared in `namespace System`). Extension-member lookup requires the containing namespace to be imported, so qualifying the receiver would clear CS0103 but leave CS0117/CS1061 on older frameworks.

## Fix

Added `src/NetEvolve.Arguments.Analyser/UsingDirectiveInserter.cs`, a small helper (`EnsureSystemUsingDirective`) that inserts `using System;` into the fixed compilation unit if one isn't already present — handling a file-scoped namespace, a block-scoped namespace, or no namespace at all. It only checks for a plain (non-aliased) `using System;`, so it is not fooled by an unrelated alias.

Wired the helper into all nine code fix providers, right before `document.WithSyntaxRoot(newRoot)` (and, for `ThrowIfNullCodeFixProvider`'s coalesce path, after `editor.GetChangedDocument()`), one line each:
- `ThrowIfNullCodeFixProvider.cs` (both the `if`-statement and coalesce paths)
- `ThrowIfContainsWhiteSpaceCodeFixProvider.cs`
- `ThrowIfCountCodeFixProvider.cs`
- `ThrowIfDefaultCodeFixProvider.cs`
- `ThrowIfDisposedCodeFixProvider.cs`
- `ThrowIfEmptyGuidCodeFixProvider.cs`
- `ThrowIfLengthCodeFixProvider.cs`
- `ThrowIfNullOrEmptyCodeFixProvider.cs`
- `ThrowIfOutOfRangeCodeFixProvider.cs`

`UsingDirectiveInserter` is intentionally a new file rather than an addition to `SyntaxHelpers.cs`, since that file is owned by another agent in this batch.

**Alias-qualified form** (`using SysArg = System; ... throw new SysArg.ArgumentNullException(...)`): also handled. `EnsureSystemUsingDirective` only recognizes a non-aliased `using System;`, so an alias-only import doesn't satisfy the check, and a plain `using System;` is added alongside the alias — resolving the same binding problem for that case too.

## Regression test

Added `CodeFix_WhenSourceHasNoUsingSystemAndThrowIsFullyQualified_AddsUsingSystemDirective` to `tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs`: a fully-qualified `throw new System.ArgumentNullException(nameof(argument))` with no `using System;` in the source, asserting the fixed source contains both `ArgumentNullException.ThrowIfNull(argument);` and `using System;`.

Verified by temporarily reverting just the `ThrowIfNullCodeFixProvider.cs` change (via `git stash`) and re-running the suite: the new test failed as expected (missing `using System;` in the output), then passed again after restoring the fix.

The change to the other eight providers is mechanical (identical one-line insertion at the same site in each), so one provider's test is considered sufficient coverage per the task guidance; happy to add more if desired.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings/errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 104/104 passed.
