### PR TITLE
fix(analyser): add semantic type gates to NEA0009 Guid.Empty check

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidAnalyzer.cs
@@ -2,6 +2,7 @@ namespace NetEvolve.Arguments.Analyser;
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -13,6 +14,9 @@ public sealed class ThrowIfEmptyGuidAnalyzer : DiagnosticAnalyzer
 {
     /// <summary>The fully-qualified metadata name of <see cref="ArgumentException"/>.</summary>
     private const string ArgumentExceptionMetadataName = "System.ArgumentException";
+
+    /// <summary>The fully-qualified metadata name of <see cref="Guid"/>.</summary>
+    private const string GuidMetadataName = "System.Guid";
 
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
@@ -37,7 +41,22 @@ public sealed class ThrowIfEmptyGuidAnalyzer : DiagnosticAnalyzer
     {
         var ifStatement = (IfStatementSyntax)context.Node;
 
-        if (!TryGetEmptyGuidCheckedExpression(ifStatement.Condition, out var argument) || argument is null)
+        if (
+            !TryGetEmptyGuidCheckedExpression(
+                ifStatement.Condition,
+                context.SemanticModel,
+                context.CancellationToken,
+                out var argument
+            ) || argument is null
+        )
+        {
+            return;
+        }
+
+        var guidType = context.SemanticModel.Compilation.GetTypeByMetadataName(GuidMetadataName);
+        var argumentType = context.SemanticModel.GetTypeInfo(argument, context.CancellationToken).Type;
+
+        if (guidType is null || !SymbolEqualityComparer.Default.Equals(argumentType, guidType))
         {
             return;
         }
@@ -67,9 +86,16 @@ public sealed class ThrowIfEmptyGuidAnalyzer : DiagnosticAnalyzer
 
     /// <summary>Recognizes <c>arg.Equals(Guid.Empty)</c> and <c>arg == Guid.Empty</c>/<c>Guid.Empty == arg</c>.</summary>
     /// <param name="condition">The <c>if</c> statement's condition expression.</param>
+    /// <param name="semanticModel">The semantic model used to resolve <c>Guid.Empty</c>.</param>
+    /// <param name="cancellationToken">The token used to cancel semantic-model lookups.</param>
     /// <param name="argument">When this method returns <see langword="true"/>, the expression being checked; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if <paramref name="condition"/> is a recognized <c>Guid.Empty</c>-check shape; otherwise, <see langword="false"/>.</returns>
-    internal static bool TryGetEmptyGuidCheckedExpression(ExpressionSyntax condition, out ExpressionSyntax? argument)
+    internal static bool TryGetEmptyGuidCheckedExpression(
+        ExpressionSyntax condition,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax? argument
+    )
     {
         condition = SyntaxHelpers.Unwrap(condition);
         argument = null;
@@ -80,18 +106,19 @@ public sealed class ThrowIfEmptyGuidAnalyzer : DiagnosticAnalyzer
             {
                 Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: "Equals" } access,
                 ArgumentList.Arguments.Count: 1,
-            } invocation when IsGuidEmpty(invocation.ArgumentList.Arguments[0].Expression):
+            } invocation
+                when IsGuidEmpty(invocation.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken):
                 argument = access.Expression;
                 return true;
 
             case BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.EqualsExpression):
-                if (IsGuidEmpty(binary.Right))
+                if (IsGuidEmpty(binary.Right, semanticModel, cancellationToken))
                 {
                     argument = binary.Left;
                     return true;
                 }
 
-                if (IsGuidEmpty(binary.Left))
+                if (IsGuidEmpty(binary.Left, semanticModel, cancellationToken))
                 {
                     argument = binary.Right;
                     return true;
@@ -103,14 +130,30 @@ public sealed class ThrowIfEmptyGuidAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    /// <summary>Determines whether an expression is a <c>Guid.Empty</c> member access.</summary>
+    /// <summary>Determines whether an expression is a reference to the real <see cref="Guid.Empty"/> field.</summary>
     /// <param name="expression">The expression to test.</param>
-    /// <returns><see langword="true"/> if <paramref name="expression"/> is <c>Guid.Empty</c>; otherwise, <see langword="false"/>.</returns>
-    private static bool IsGuidEmpty(ExpressionSyntax expression) =>
-        SyntaxHelpers.Unwrap(expression)
-            is MemberAccessExpressionSyntax
-            {
-                Expression: IdentifierNameSyntax { Identifier.Text: "Guid" },
-                Name.Identifier.Text: "Empty",
-            };
+    /// <param name="semanticModel">The semantic model used to resolve the expression's symbol.</param>
+    /// <param name="cancellationToken">The token used to cancel semantic-model lookups.</param>
+    /// <returns><see langword="true"/> if <paramref name="expression"/> resolves to <see cref="Guid.Empty"/>; otherwise, <see langword="false"/>.</returns>
+    private static bool IsGuidEmpty(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken
+    )
+    {
+        if (
+            SyntaxHelpers.Unwrap(expression)
+            is not MemberAccessExpressionSyntax { Name.Identifier.Text: "Empty" } memberAccess
+        )
+        {
+            return false;
+        }
+
+        var symbol = semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol;
+        var guidType = semanticModel.Compilation.GetTypeByMetadataName(GuidMetadataName);
+
+        return guidType is not null
+            && symbol is IFieldSymbol { Name: "Empty" } field
+            && SymbolEqualityComparer.Default.Equals(field.ContainingType, guidType);
+    }
 }

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidCodeFixProvider.cs
@@ -66,10 +66,17 @@ public sealed class ThrowIfEmptyGuidCodeFixProvider : CodeFixProvider
     )
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
         if (
             root is null
-            || !ThrowIfEmptyGuidAnalyzer.TryGetEmptyGuidCheckedExpression(ifStatement.Condition, out var argument)
+            || semanticModel is null
+            || !ThrowIfEmptyGuidAnalyzer.TryGetEmptyGuidCheckedExpression(
+                ifStatement.Condition,
+                semanticModel,
+                cancellationToken,
+                out var argument
+            )
             || argument is null
         )
         {

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfEmptyGuidAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfEmptyGuidAnalyzerTests.cs
@@ -61,6 +61,75 @@ public sealed class ThrowIfEmptyGuidAnalyzerTests
     }
 
     [Test]
+    public async Task Analyze_WhenArgumentIsNullableGuid_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(Guid? argument)
+                {
+                    if (argument == Guid.Empty) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfEmptyGuidAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenArgumentIsObject_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(object argument)
+                {
+                    if (argument.Equals(Guid.Empty)) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfEmptyGuidAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenGuidIsUserDefinedType_DoesNotReportDiagnostic()
+    {
+        const string source = """
+            using System;
+            using Guid = Other.Guid;
+
+            namespace Other
+            {
+                struct Guid
+                {
+                    public static readonly Guid Empty = new Guid();
+                }
+            }
+
+            class C
+            {
+                void M(Guid argument)
+                {
+                    if (argument.Equals(Guid.Empty)) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfEmptyGuidAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task CodeFix_WhenApplied_ReplacesWithThrowIfEmptyGuidCall()
     {
         const string source = """


### PR DESCRIPTION
## Defect

`ThrowIfEmptyGuidAnalyzer` (rule NEA0009) matched `Guid.Empty` by raw
token text — it required an `IdentifierNameSyntax` receiver whose
text was literally `"Guid"` — and never resolved either the
`Guid.Empty` symbol or the type of the validated expression via the
semantic model. As a result, NEA0009 fired on `Guid?`, `object`, and
same-named user types from other namespaces, and the code fix emitted
non-compiling (or semantically wrong) code.

### Before

```csharp
void M(Guid? a)
{
    if (a == Guid.Empty) throw new ArgumentException(nameof(a));
}
```

NEA0009 fires and the code fix produces:

```csharp
ArgumentException.ThrowIfEmptyGuid(a);
```

which is **CS1503** (`Guid?` cannot convert to `Guid`) and, even
ignoring the compile error, silently changes behavior: the original
lifted `==` is `false` when `a` is `null`, while
`ThrowIfEmptyGuid` checks the value directly.

### After

The analyzer no longer reports for `Guid?`, `object`, or a same-named
`Guid` type from another namespace. It still reports for the genuine
`System.Guid` case, and the code fix still produces
`ArgumentException.ThrowIfEmptyGuid(argument);` for that case.

## Fix

In `src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidAnalyzer.cs`,
after the existing syntactic gates, two semantic gates are added
using `context.SemanticModel`:

1. The validated expression's resolved type must equal
   `System.Guid` exactly (via `GetTypeInfo` +
   `SymbolEqualityComparer`), rejecting `Nullable<Guid>`, `object`,
   and unrelated same-named types.
2. The `Guid.Empty` reference is resolved with `GetSymbolInfo` and
   must be the real `System.Guid.Empty` field, rather than matched
   by text.

`context.CancellationToken` is threaded through both new helper
overloads.

`ThrowIfEmptyGuidCodeFixProvider.cs` required a small consequential
update: `TryGetEmptyGuidCheckedExpression` now takes a
`SemanticModel` and `CancellationToken`, so the code fix provider
fetches the document's semantic model before calling it. No other
behavior in that file changed.

## Tests added (`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfEmptyGuidAnalyzerTests.cs`)

- `Analyze_WhenArgumentIsNullableGuid_DoesNotReportDiagnostic` — `Guid? argument` compared against `Guid.Empty`.
- `Analyze_WhenArgumentIsObject_DoesNotReportDiagnostic` — `object argument` compared via `.Equals(Guid.Empty)`.
- `Analyze_WhenGuidIsUserDefinedType_DoesNotReportDiagnostic` — a user-defined `struct Guid` in another namespace, referenced through a `using Guid = Other.Guid;` alias so it still matches the old text-based check.
- Existing positive `Guid` cases (`==`, reversed `==`, `.Equals(...)`) and the code-fix test still pass unchanged.

## Verification

- Confirmed regression: stashed the fix and reran the suite — exactly
  the 3 new tests failed (103/106 passing), confirming they exercise
  the defect.
- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings/errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 106/106 passing.
