### PR TITLE
fix(analyser): wrap embedded statements in a block for the coalesce ThrowIfNull fix

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
@@ -139,12 +139,30 @@ public sealed class ThrowIfNullCodeFixProvider : CodeFixProvider
             .WithLeadingTrivia(containingStatement.GetLeadingTrivia())
             .WithAdditionalAnnotations(Formatter.Annotation);
 
-        editor.InsertBefore(containingStatement, throwIfNullStatement);
-        editor.ReplaceNode(coalesce, argument.WithoutTrivia());
-        editor.ReplaceNode(
-            containingStatement,
-            (currentNode, _) => currentNode.WithLeadingTrivia(SyntaxFactory.ElasticMarker)
-        );
+        if (containingStatement.Parent is BlockSyntax or SwitchSectionSyntax)
+        {
+            editor.InsertBefore(containingStatement, throwIfNullStatement);
+            editor.ReplaceNode(coalesce, argument.WithoutTrivia());
+            editor.ReplaceNode(
+                containingStatement,
+                (currentNode, _) => currentNode.WithLeadingTrivia(SyntaxFactory.ElasticMarker)
+            );
+        }
+        else
+        {
+            // The containing statement is an embedded statement (e.g. the body of a while/do/for/foreach/using/lock/fixed
+            // without braces). Its parent does not hold a statement list, so DocumentEditor.InsertBefore has nothing to
+            // insert into. Introduce a block instead, so the hoisted ThrowIfNull call has somewhere to live.
+            var rewrittenStatement = containingStatement.ReplaceNode(coalesce, argument.WithoutTrivia());
+
+            var block = SyntaxFactory
+                .Block(throwIfNullStatement.WithoutLeadingTrivia(), rewrittenStatement.WithoutLeadingTrivia())
+                .WithLeadingTrivia(containingStatement.GetLeadingTrivia())
+                .WithTrailingTrivia(containingStatement.GetTrailingTrivia())
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            editor.ReplaceNode(containingStatement, block);
+        }
 
         var changedDocument = editor.GetChangedDocument();
         var changedRoot = await changedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -195,6 +195,71 @@ public sealed class ThrowIfNullAnalyzerTests
         _ = await Assert.That(fixedSource).Contains("_value = argument;");
     }
 
+    [Test]
+    public async Task CodeFix_WhenAppliedToCoalesceInWhileEmbeddedStatement_WrapsInBlock()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private string _value = string.Empty;
+
+                void M(string? argument, bool flag)
+                {
+                    while (flag)
+                        _value = argument ?? throw new ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        var normalized = fixedSource.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        _ = await Assert.That(normalized).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(normalized).Contains("_value = argument;");
+        _ = await Assert.That(normalized).DoesNotContain("throw new ArgumentNullException");
+        _ = await Assert.That(normalized).Contains("while (flag)\n        {");
+    }
+
+    [Test]
+    public async Task CodeFix_WhenAppliedToCoalesceInLockEmbeddedStatement_WrapsInBlock()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private string _value = string.Empty;
+                private readonly object _gate = new();
+
+                void M(string? argument)
+                {
+                    lock (_gate)
+                        _value = argument ?? throw new ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        var normalized = fixedSource.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        _ = await Assert.That(normalized).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(normalized).Contains("_value = argument;");
+        _ = await Assert.That(normalized).DoesNotContain("throw new ArgumentNullException");
+        _ = await Assert.That(normalized).Contains("lock (_gate)\n        {");
+    }
+
     private static int CountOccurrences(string source, string value)
     {
         var count = 0;

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -228,6 +228,39 @@ public sealed class ThrowIfNullAnalyzerTests
     }
 
     [Test]
+    public async Task CodeFix_WhenAppliedToCoalesceInWhileEmbeddedStatementWithLeadingComment_DoesNotDuplicateComment()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                private string _value = string.Empty;
+
+                void M(string? argument, bool flag)
+                {
+                    while (flag)
+                        // validate input
+                        _value = argument ?? throw new ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        var commentOccurrences = CountOccurrences(fixedSource, "// validate input");
+
+        _ = await Assert.That(commentOccurrences).IsEqualTo(1);
+        _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
+        _ = await Assert.That(fixedSource).Contains("_value = argument;");
+        _ = await Assert.That(fixedSource).DoesNotContain("throw new ArgumentNullException(nameof(argument))");
+    }
+
+    [Test]
     public async Task CodeFix_WhenAppliedToCoalesceInLockEmbeddedStatement_WrapsInBlock()
     {
         const string source = """


### PR DESCRIPTION
**Expected conflict:** this PR touches `src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs`. Three other agents are concurrently editing the same file for separate findings (coalesce-vs-if dispatch, leading-trivia duplication, and the missing `using System;` insertion). This is a known, accepted conflict — one PR per finding, per repo owner.

## Defect (severity LOW)

`ThrowIfNullCodeFixProvider.ApplyCoalesceFixAsync` resolves the statement containing the `??` throw-expression via `coalesce.FirstAncestorOrSelf<StatementSyntax>()` and then calls `editor.InsertBefore(containingStatement, throwIfNullStatement)`. `DocumentEditor.InsertBefore` resolves internally to `SyntaxReplacer.InsertNodeInList`, which requires the statement's parent to hold an actual statement **list** (`BlockSyntax` or `SwitchSectionSyntax`).

Nothing verified that precondition. When the coalesce-throw sits in a brace-less **embedded statement** — the body of `while`, `do`, `for`, `foreach`, `using`, `lock`, or `fixed` without braces — the parent is the loop/using/lock statement itself, not a list holder, and the fix throws at runtime instead of applying.

(`if`/`else` embedded statements are not affected — they're intercepted earlier by the `IfStatementSyntax` ancestor check and never reach this code path. `SwitchSectionSyntax` is also fine, since its `Statements` property is itself a list.)

### Before

```csharp
void M(string? argument, bool flag)
{
    while (flag)
        _value = argument ?? throw new ArgumentNullException(nameof(argument));
}
```

Invoking the code fix threw `InvalidOperationException` from deep inside `SyntaxReplacer.InsertNodeInList` — confirmed locally before the fix (see test verification below).

### After

```csharp
void M(string? argument, bool flag)
{
    while (flag)
    {
        ArgumentNullException.ThrowIfNull(argument);
        _value = argument;
    }
}
```

## Fix

In `ApplyCoalesceFixAsync`, branch on whether `containingStatement.Parent` is a list-holding node (`BlockSyntax or SwitchSectionSyntax`):
- If so: behave exactly as before (`InsertBefore` + `ReplaceNode`).
- If not: build a new `BlockSyntax` containing the hoisted `ArgumentNullException.ThrowIfNull(...)` call followed by the rewritten original statement, carry over the original statement's leading/trailing trivia, annotate with `Formatter.Annotation`, and replace the embedded statement with this block.

The check is a whitelist of list-holding parents rather than an enumeration of the seven embedded-statement kinds, so it also covers `if`/`else` embedded statements automatically once the sibling if/coalesce-dispatch fix (owned by another agent) starts routing those through this code path.

## Tests added (`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs`)

- `CodeFix_WhenAppliedToCoalesceInWhileEmbeddedStatement_WrapsInBlock` — brace-less `while` body.
- `CodeFix_WhenAppliedToCoalesceInLockEmbeddedStatement_WrapsInBlock` — brace-less `lock` body.

Both assert the hoisted `ArgumentNullException.ThrowIfNull(argument);` call, the rewritten assignment, the absence of the original throw expression, and (after normalizing `\r\n` to `\n`) that a brace immediately follows the loop/lock header — i.e. a genuine block was introduced, not just text present anywhere in the file.

## Verification

- Confirmed both new tests fail with `InvalidOperationException` (`SyntaxReplacer.InsertNodeInList`) against the pre-fix code (stashed the source change and re-ran).
- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds (CSharpier.MSBuild formatting included).
- `dotnet build tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — succeeds.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 105/105 pass.

## Out of scope (tracked separately, owned by other agents)

- Coalesce-vs-if dispatch bug (`RegisterCodeFixesAsync`, lines ~41-56).
- Leading-trivia duplication on the hoisted `ThrowIfNull` statement (line ~133).
- Hoisting out of lambdas/ternaries (analyzer-side gate).
- Unqualified exception names / missing `using System;` insertion.
