### PR TITLE
fix(analyser): preserve interior comments when replacing if-throw statements

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceCodeFixProvider.cs
@@ -92,7 +92,7 @@ public sealed class ThrowIfContainsWhiteSpaceCodeFixProvider : CodeFixProvider
                     )
                 )
             )
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfCountCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfCountCodeFixProvider.cs
@@ -100,7 +100,7 @@ public sealed class ThrowIfCountCodeFixProvider : CodeFixProvider
                     )
                 )
             )
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfDefaultCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfDefaultCodeFixProvider.cs
@@ -89,7 +89,7 @@ public sealed class ThrowIfDefaultCodeFixProvider : CodeFixProvider
                     )
                 )
             )
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfDisposedCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfDisposedCodeFixProvider.cs
@@ -91,7 +91,7 @@ public sealed class ThrowIfDisposedCodeFixProvider : CodeFixProvider
                     )
                 )
             )
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfEmptyGuidCodeFixProvider.cs
@@ -89,7 +89,7 @@ public sealed class ThrowIfEmptyGuidCodeFixProvider : CodeFixProvider
                     )
                 )
             )
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfLengthCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfLengthCodeFixProvider.cs
@@ -100,7 +100,7 @@ public sealed class ThrowIfLengthCodeFixProvider : CodeFixProvider
                     )
                 )
             )
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullCodeFixProvider.cs
@@ -90,7 +90,7 @@ public sealed class ThrowIfNullCodeFixProvider : CodeFixProvider
 
         var throwIfNullInvocation = SyntaxFactory
             .ExpressionStatement(CreateThrowIfNullInvocation(argument))
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, throwIfNullInvocation);

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullOrEmptyCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullOrEmptyCodeFixProvider.cs
@@ -94,7 +94,7 @@ public sealed class ThrowIfNullOrEmptyCodeFixProvider : CodeFixProvider
                     )
                 )
             )
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfOutOfRangeCodeFixProvider.cs
@@ -111,7 +111,7 @@ public sealed class ThrowIfOutOfRangeCodeFixProvider : CodeFixProvider
                     )
                 )
             )
-            .WithTriviaFrom(ifStatement)
+            .WithTriviaFromPreservingComments(ifStatement)
             .WithAdditionalAnnotations(Formatter.Annotation);
 
         var newRoot = root.ReplaceNode(ifStatement, invocation);

--- a/src/NetEvolve.Arguments.Analyser/TriviaHelpers.cs
+++ b/src/NetEvolve.Arguments.Analyser/TriviaHelpers.cs
@@ -1,0 +1,56 @@
+namespace NetEvolve.Arguments.Analyser;
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+/// <summary>Shared trivia-preservation helpers used by the code fix providers that replace an <c>if</c> statement.</summary>
+internal static class TriviaHelpers
+{
+    /// <summary>
+    /// Copies the leading and trailing trivia of <paramref name="ifStatement"/> onto <paramref name="replacement"/>,
+    /// exactly like the <c>WithTriviaFrom</c> extension method, and additionally re-inserts any comment trivia attached
+    /// to tokens INSIDE the <c>if</c> statement's subtree (for example, a comment on its own line right before the
+    /// <c>throw</c> statement inside the block) that <c>WithTriviaFrom</c> alone would silently discard, since it
+    /// only carries the leading trivia of the <c>if</c> keyword and the trailing trivia after the closing brace.
+    /// </summary>
+    /// <typeparam name="TNode">The type of the replacement syntax node.</typeparam>
+    /// <param name="replacement">The node that is replacing <paramref name="ifStatement"/>.</param>
+    /// <param name="ifStatement">The <c>if</c> statement being replaced.</param>
+    /// <returns><paramref name="replacement"/> with the <c>if</c> statement's trivia and any interior comments preserved.</returns>
+    public static TNode WithTriviaFromPreservingComments<TNode>(this TNode replacement, IfStatementSyntax ifStatement)
+        where TNode : SyntaxNode
+    {
+        var withOuterTrivia = replacement.WithTriviaFrom(ifStatement);
+
+        // These are the trivia lists WithTriviaFrom already carried over; anything found in them must not be
+        // duplicated when we scan the whole subtree for comments below.
+        var alreadyCarried = new HashSet<SyntaxTrivia>(
+            ifStatement.GetLeadingTrivia().Concat(ifStatement.GetTrailingTrivia())
+        );
+
+        var interiorComments = ifStatement
+            .DescendantTrivia()
+            .Where(trivia =>
+                trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia)
+            )
+            .Where(trivia => !alreadyCarried.Contains(trivia))
+            .ToList();
+
+        if (interiorComments.Count == 0)
+        {
+            return withOuterTrivia;
+        }
+
+        var preservedTrivia = interiorComments.SelectMany(comment =>
+            new[] { comment, SyntaxFactory.ElasticCarriageReturnLineFeed }
+        );
+
+        // Append after whatever leading trivia was already carried over (e.g. a comment preceding the `if` itself),
+        // so the interior comments keep appearing immediately before the replacement statement, matching their
+        // original source position right before the `throw`.
+        return withOuterTrivia.WithLeadingTrivia(withOuterTrivia.GetLeadingTrivia().Concat(preservedTrivia));
+    }
+}

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDefaultAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDefaultAnalyzerTests.cs
@@ -1,5 +1,7 @@
 namespace NetEvolve.Arguments.Analyser.Tests.Unit;
 
+using System;
+
 public sealed class ThrowIfDefaultAnalyzerTests
 {
     [Test]
@@ -105,4 +107,51 @@ public sealed class ThrowIfDefaultAnalyzerTests
 
         _ = await Assert.That(fixedSource).Contains("ArgumentException.ThrowIfDefault(argument);");
     }
+
+    [Test]
+    public async Task CodeFix_WhenBlockContainsInteriorComment_PreservesCommentExactlyOnce()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(Guid argument)
+                {
+                    // guard below
+                    if (argument.Equals(default))
+                    {
+                        // see bug #431
+                        throw new ArgumentException(nameof(argument));
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfDefaultAnalyzer(),
+            new ThrowIfDefaultCodeFixProvider(),
+            source
+        );
+
+        _ = await Assert.That(fixedSource).Contains("ArgumentException.ThrowIfDefault(argument);");
+
+        // The comment that already precedes the `if` statement (carried over by WithTriviaFrom) must not be
+        // duplicated, and the interior comment (attached to the `throw` inside the block, which WithTriviaFrom
+        // alone would drop) must be preserved exactly once, immediately before the replacement statement.
+        var guardOccurrences = CountOccurrences(fixedSource, "// guard below");
+        var interiorOccurrences = CountOccurrences(fixedSource, "// see bug #431");
+
+        _ = await Assert.That(guardOccurrences).IsEqualTo(1);
+        _ = await Assert.That(interiorOccurrences).IsEqualTo(1);
+        _ = await Assert
+            .That(fixedSource.IndexOf("// guard below", StringComparison.Ordinal))
+            .IsLessThan(fixedSource.IndexOf("// see bug #431", StringComparison.Ordinal));
+        _ = await Assert
+            .That(fixedSource)
+            .Contains($"// see bug #431{Environment.NewLine}        ArgumentException.ThrowIfDefault");
+    }
+
+    private static int CountOccurrences(string text, string value) =>
+        text.Split([value], StringSplitOptions.None).Length - 1;
 }


### PR DESCRIPTION
**Expected conflict:** this PR touches the shared `.WithTriviaFrom(ifStatement)` + `ReplaceNode` pair in all nine code fix providers. Other agents are concurrently editing `ThrowIfNullCodeFixProvider.cs` and `ThrowIfDisposedCodeFixProvider.cs` for separate findings (one PR per finding, accepted by the repo owner). Expect a merge conflict there; the change in this PR is a single one-line swap per file (`WithTriviaFrom` -> `WithTriviaFromPreservingComments`), so it should be trivial to reapply on top of the other PR.

## Defect (severity LOW, cosmetic)

`WithTriviaFrom(ifStatement)` only copies the **leading trivia of the `if` keyword** and the **trailing trivia after the closing `}`**. Trivia attached to interior tokens is dropped entirely. Since comments are trivia, not statements, a one-statement block containing a comment is genuinely reached by `SyntaxHelpers.GetSingleThrowStatement` and silently loses that comment when a code fix rewrites the `if` into a single throw-helper call.

### Before

```csharp
if (s is null)
{
    // see bug #431
    throw new ArgumentNullException(nameof(s));
}
```

### After the fix is applied (before this change)

```csharp
ArgumentNullException.ThrowIfNull(s);
```

The `// see bug #431` comment vanished. The output still compiles — this is cosmetic, but it silently discards user content.

### After this change

```csharp
// see bug #431
ArgumentNullException.ThrowIfNull(s);
```

The coalesce (`arg ?? throw ...`) fix path is unaffected — it never used `WithTriviaFrom(ifStatement)` in the first place.

## Fix

Added `TriviaHelpers.WithTriviaFromPreservingComments<TNode>` (new file `src/NetEvolve.Arguments.Analyser/TriviaHelpers.cs`, kept separate from `SyntaxHelpers.cs` since that file is owned by another agent this batch):

1. Copies leading/trailing trivia from the `if` statement exactly like `WithTriviaFrom` did.
2. Scans the `if` statement's subtree for `SingleLineCommentTrivia`/`MultiLineCommentTrivia`, excluding any trivia already present in the `if` statement's own leading/trailing trivia (which `WithTriviaFrom` already carried) — this avoids re-emitting the same comment twice.
3. Appends the remaining (interior) comments to the replacement's leading trivia, immediately before the statement, preserving their original relative order.
4. `DisabledTextTrivia` and preprocessor directives are intentionally excluded (out of scope; they need different handling).

Applied to all nine code fix providers that replace an `if` statement this way:
`ThrowIfNullCodeFixProvider`, `ThrowIfContainsWhiteSpaceCodeFixProvider`, `ThrowIfCountCodeFixProvider`, `ThrowIfDefaultCodeFixProvider`, `ThrowIfDisposedCodeFixProvider`, `ThrowIfEmptyGuidCodeFixProvider`, `ThrowIfLengthCodeFixProvider`, `ThrowIfNullOrEmptyCodeFixProvider`, `ThrowIfOutOfRangeCodeFixProvider`.

## Test added

`ThrowIfDefaultAnalyzerTests.CodeFix_WhenBlockContainsInteriorComment_PreservesCommentExactlyOnce` (`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDefaultAnalyzerTests.cs`):

- Source has both a comment preceding the `if` (already carried by `WithTriviaFrom`) and a comment inside the block right before the `throw` (the one that used to be dropped).
- Asserts each comment appears **exactly once** in the fixed source (guards against the naive-fix failure mode of re-emitting the already-carried comment).
- Asserts the pre-`if` comment still precedes the interior comment (order preserved).
- Asserts the interior comment renders immediately before the replacement statement, correctly indented (formatting is Formatter-annotated, verified empirically).

The change is mechanical and identical across the other eight providers (same one-line swap), so a single provider's test is sufficient coverage; I didn't duplicate it nine times to keep the diff focused.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings, 0 errors (CSharpier formatting applied on build).
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 104/104 passed.
- Confirmed the new test fails before the fix (reverted the `ThrowIfDefaultCodeFixProvider` line back to `WithTriviaFrom(ifStatement)` locally, saw the assertion fail with 0 occurrences of the interior comment) and passes after re-applying the fix.
