### PR TITLE
fix(analyser): probe both ThrowIfNullOrEmpty and ThrowIfNullOrWhiteSpace

### DIFF
--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullOrEmptyAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullOrEmptyAnalyzer.cs
@@ -31,27 +31,61 @@ public sealed class ThrowIfNullOrEmptyAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationStartAction(OnCompilationStart);
     }
 
-    /// <summary>Registers the syntax-node action for this rule, unless the compilation's BCL already exposes <c>ArgumentException.ThrowIfNullOrEmpty</c>.</summary>
+    /// <summary>
+    /// Probes the compilation's BCL for both <c>ArgumentException.ThrowIfNullOrEmpty</c> and <c>ArgumentException.ThrowIfNullOrWhiteSpace</c>,
+    /// and registers the syntax-node action unless both are already present.
+    /// </summary>
     /// <param name="context">The compilation-start context supplied by the Roslyn analyzer driver.</param>
     private static void OnCompilationStart(CompilationStartAnalysisContext context)
     {
-        // The BCL exposes these throw-helpers since .NET 8; where it does, the built-in
-        // CA1511 analyzer already covers this pattern, so stay silent to avoid duplicates.
-        if (SyntaxHelpers.HasBuiltInMember(context.Compilation, ArgumentExceptionMetadataName, "ThrowIfNullOrEmpty"))
+        // The BCL exposes ThrowIfNullOrEmpty since .NET 7 and ThrowIfNullOrWhiteSpace since .NET 8; where a
+        // given helper already exists, the built-in CA1511 analyzer already covers that shape, so this rule
+        // must stay silent for it to avoid duplicates. The two helpers can be independently available (e.g.
+        // net7.0's System.Runtime declares only ThrowIfNullOrEmpty), so each is probed separately and the
+        // per-branch suppression happens in Analyze; only skip registration entirely when both already exist.
+        var hasThrowIfNullOrEmpty = SyntaxHelpers.HasBuiltInMember(
+            context.Compilation,
+            ArgumentExceptionMetadataName,
+            "ThrowIfNullOrEmpty"
+        );
+        var hasThrowIfNullOrWhiteSpace = SyntaxHelpers.HasBuiltInMember(
+            context.Compilation,
+            ArgumentExceptionMetadataName,
+            "ThrowIfNullOrWhiteSpace"
+        );
+
+        if (hasThrowIfNullOrEmpty && hasThrowIfNullOrWhiteSpace)
         {
             return;
         }
 
-        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.IfStatement);
+        context.RegisterSyntaxNodeAction(
+            nodeContext => Analyze(nodeContext, hasThrowIfNullOrEmpty, hasThrowIfNullOrWhiteSpace),
+            SyntaxKind.IfStatement
+        );
     }
 
     /// <summary>Analyzes an <c>if</c> statement and reports NEA0002 when it is a <c>string.IsNullOrEmpty</c>/<c>IsNullOrWhiteSpace</c>-then-throw of <see cref="ArgumentException"/>.</summary>
     /// <param name="context">The syntax-node analysis context for the <c>if</c> statement being visited.</param>
-    private static void Analyze(SyntaxNodeAnalysisContext context)
+    /// <param name="hasThrowIfNullOrEmpty">Whether the compilation's BCL already exposes <c>ArgumentException.ThrowIfNullOrEmpty</c>.</param>
+    /// <param name="hasThrowIfNullOrWhiteSpace">Whether the compilation's BCL already exposes <c>ArgumentException.ThrowIfNullOrWhiteSpace</c>.</param>
+    private static void Analyze(
+        SyntaxNodeAnalysisContext context,
+        bool hasThrowIfNullOrEmpty,
+        bool hasThrowIfNullOrWhiteSpace
+    )
     {
         var ifStatement = (IfStatementSyntax)context.Node;
 
         if (!TryGetStringCheck(ifStatement.Condition, out var argument, out var helperName) || argument is null)
+        {
+            return;
+        }
+
+        if (
+            (helperName is "ThrowIfNullOrEmpty" && hasThrowIfNullOrEmpty)
+            || (helperName is "ThrowIfNullOrWhiteSpace" && hasThrowIfNullOrWhiteSpace)
+        )
         {
             return;
         }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullOrEmptyAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullOrEmptyAnalyzerTests.cs
@@ -1,5 +1,14 @@
 namespace NetEvolve.Arguments.Analyser.Tests.Unit;
 
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
 public sealed class ThrowIfNullOrEmptyAnalyzerTests
 {
     [Test]
@@ -85,6 +94,159 @@ public sealed class ThrowIfNullOrEmptyAnalyzerTests
         );
 
         _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenOnlyThrowIfNullOrEmptyIsBuiltIn_StillReportsDiagnosticForIsNullOrWhiteSpace()
+    {
+        // Simulates net7.0's System.Runtime shape, where ArgumentException.ThrowIfNullOrEmpty already exists
+        // but ArgumentException.ThrowIfNullOrWhiteSpace does not (it arrived only in .NET 8). Gating the whole
+        // rule on a single probe for "ThrowIfNullOrEmpty" would wrongly suppress this IsNullOrWhiteSpace case,
+        // even though NetEvolve.Arguments's own polyfill supplies that helper for exactly that framework.
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    if (string.IsNullOrWhiteSpace(argument)) throw new ArgumentException("", nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsWithOnlyThrowIfNullOrEmptyBuiltInAsync(source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0002");
+    }
+
+    [Test]
+    public async Task Analyze_WhenOnlyThrowIfNullOrEmptyIsBuiltIn_DoesNotReportDiagnosticForIsNullOrEmpty()
+    {
+        // Same simulated net7.0 shape as above, but for the branch whose built-in helper already exists:
+        // that branch must stay suppressed to avoid duplicating the built-in CA1511 analyzer.
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    if (string.IsNullOrEmpty(argument)) throw new ArgumentException("", nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsWithOnlyThrowIfNullOrEmptyBuiltInAsync(source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> against a minimal, hand-written substitute BCL whose <c>System.ArgumentException</c>
+    /// declares only <c>ThrowIfNullOrEmpty</c> — reproducing net7.0's System.Runtime shape, which neither of
+    /// <see cref="AnalyzerVerifier"/>'s two reference sets (all built-ins present, or none) can represent.
+    /// </summary>
+    /// <param name="source">The C# source to analyze.</param>
+    /// <returns>The diagnostics <see cref="ThrowIfNullOrEmptyAnalyzer"/> reports for <paramref name="source"/>.</returns>
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithOnlyThrowIfNullOrEmptyBuiltInAsync(
+        string source
+    )
+    {
+        const string stubBclSource = """
+            namespace System
+            {
+                public class Object
+                {
+                    public virtual bool Equals(object? obj) => false;
+                    public virtual int GetHashCode() => 0;
+                    public virtual string? ToString() => null;
+                }
+
+                public class Void { }
+
+                public struct Boolean { }
+
+                public struct Int32 { }
+
+                public struct Char { }
+
+                public class String
+                {
+                    public static bool IsNullOrEmpty(string? value) => false;
+
+                    public static bool IsNullOrWhiteSpace(string? value) => false;
+                }
+
+                public class ValueType { }
+
+                public struct Nullable<T>
+                    where T : struct { }
+
+                public class Attribute { }
+
+                public class Exception
+                {
+                    public Exception() { }
+
+                    public Exception(string message) { }
+                }
+
+                // Only ThrowIfNullOrEmpty is declared here, matching net7.0's System.Runtime: it introduced
+                // ArgumentException.ThrowIfNullOrEmpty, while ThrowIfNullOrWhiteSpace arrived only in .NET 8.
+                public class ArgumentException : Exception
+                {
+                    public ArgumentException() { }
+
+                    public ArgumentException(string message) : base(message) { }
+
+                    public ArgumentException(string message, string paramName) : base(message) { }
+
+                    public static void ThrowIfNullOrEmpty(string? argument, string? paramName = null) { }
+                }
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                public class RuntimeCompatibilityAttribute : System.Attribute
+                {
+                    public bool WrapNonExceptionThrows { get; set; }
+                }
+            }
+            """;
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[]
+            {
+                CSharpSyntaxTree.ParseText(stubBclSource, parseOptions),
+                CSharpSyntaxTree.ParseText(source, parseOptions),
+            },
+            Array.Empty<MetadataReference>(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        // Guard against the stub BCL silently failing to bind (e.g. a missing well-known type), which would
+        // make the "no diagnostic" assertions in the calling tests pass for the wrong reason.
+        var compilationErrors = compilation
+            .GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToImmutableArray();
+
+        if (!compilationErrors.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                $"Stub BCL compilation failed: {string.Join(Environment.NewLine, compilationErrors)}"
+            );
+        }
+
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(new ThrowIfNullOrEmptyAnalyzer())
+        );
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(CancellationToken.None).ConfigureAwait(false);
     }
 
     [Test]


### PR DESCRIPTION
## Defect

`ThrowIfNullOrEmptyAnalyzer.OnCompilationStart` gated the entire NEA0002 rule on a single probe: `SyntaxHelpers.HasBuiltInMember(compilation, "System.ArgumentException", "ThrowIfNullOrEmpty")`. But the rule emits **two** different throw-helper names depending on the recognized pattern — `ThrowIfNullOrEmpty` (from `string.IsNullOrEmpty`) and `ThrowIfNullOrWhiteSpace` (from `string.IsNullOrWhiteSpace`).

On `net7.0` — an explicitly supported TFM (see `Directory.Build.props`) — `System.Runtime` declares `ArgumentException.ThrowIfNullOrEmpty` but **not** `ThrowIfNullOrWhiteSpace` (that one arrived only in .NET 8). Because the single probe for `ThrowIfNullOrEmpty` succeeded, the whole rule was suppressed — including the `IsNullOrWhiteSpace` branch, for which no built-in helper exists on net7.0 and for which this package's own polyfill (`ArgumentExceptionPolyfill.cs`, guarded by `#if !NET8_0_OR_GREATER`) supplies exactly that method.

### Before / after

```csharp
void M(string? argument)
{
    if (string.IsNullOrWhiteSpace(argument)) throw new ArgumentException("", nameof(argument));
}
```

- Before (on net7.0): no diagnostic — silently missed, even though `ArgumentException.ThrowIfNullOrWhiteSpace` doesn't exist yet on that TFM and the polyfill provides it.
- After: `NEA0002` is reported, suggesting `ArgumentException.ThrowIfNullOrWhiteSpace(argument)`.

The `IsNullOrEmpty` branch continues to stay silent wherever the BCL already provides `ThrowIfNullOrEmpty`, so no duplicate diagnostics against the built-in CA1511 analyzer are introduced.

## Fix

`OnCompilationStart` now probes `ThrowIfNullOrEmpty` and `ThrowIfNullOrWhiteSpace` independently (once per compilation, still outside the per-node hot path) and only skips registering the syntax-node action when **both** already exist. The two booleans are captured in the registered callback's closure, and `Analyze` suppresses each branch individually based on its own probe result rather than an all-or-nothing gate.

## Test added

`tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullOrEmptyAnalyzerTests.cs`:
- `Analyze_WhenOnlyThrowIfNullOrEmptyIsBuiltIn_StillReportsDiagnosticForIsNullOrWhiteSpace` — fails before the fix (no diagnostic), passes after (NEA0002 reported).
- `Analyze_WhenOnlyThrowIfNullOrEmptyIsBuiltIn_DoesNotReportDiagnosticForIsNullOrEmpty` — companion test confirming the branch whose built-in already exists stays silent.

`AnalyzerVerifier.cs` was **not** touched (another agent is working on it in parallel, and the change here is purely additive from the test's own perspective). Its two existing reference modes ("all BCL throw-helpers present" via the modern runtime references, or "none present" via the netstandard2.1 reference assembly) cannot express the net7.0 shape of "`ThrowIfNullOrEmpty` present, `ThrowIfNullOrWhiteSpace` absent" — that mixed shape is exactly why this bug was invisible. Instead, the new tests build their own `CSharpCompilation` from a small, hand-written, minimal substitute BCL (declared as an additional source, no external references) whose `System.ArgumentException` declares only `ThrowIfNullOrEmpty`, faithfully reproducing net7.0's `System.Runtime` surface for this purpose. A guard asserts the stub compilation itself has no `DiagnosticSeverity.Error` diagnostics, so a future SDK/Roslyn change that breaks the stub's binding fails loudly instead of the "no diagnostic" assertions passing vacuously.

Note: `ThrowIfOutOfRangeAnalyzer.cs` has the same single-probe-gates-everything pattern (`ThrowIfZero` gating nine different helper names) but is deliberately left out of scope for this PR.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeds, 0 warnings (CSharpier.MSBuild ran cleanly).
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 105/105 passing, including the two new regression tests.
- Additionally hand-verified via a throwaway Roslyn probe program: with the unfixed analyzer, the reproduced net7.0 shape yields 0 diagnostics for the `IsNullOrWhiteSpace` case; with the fix applied, it yields 1 (`NEA0002`).
