### PR TITLE
test(analyser): tighten fixedSource assertions and add Fix All coverage

### DIFF
--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/AnalyzerVerifier.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/AnalyzerVerifier.cs
@@ -1,6 +1,7 @@
 namespace NetEvolve.Arguments.Analyser.Tests.Unit;
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -33,8 +34,20 @@ internal static class AnalyzerVerifier
         DiagnosticAnalyzer analyzer,
         CodeFixProvider codeFix,
         string source,
+        bool useLegacyReferences = true,
+        int expectedDiagnosticCount = 1
+    ) => ApplyFixCoreAsync(analyzer, codeFix, source, useLegacyReferences, expectedDiagnosticCount);
+
+    /// <summary>
+    /// Applies the code fix's <see cref="CodeFixProvider.GetFixAllProvider"/> (e.g. <c>WellKnownFixAllProviders.BatchFixer</c>)
+    /// across every diagnostic the analyzer reports in the document, exercising the Fix All / Batch Fixer code path.
+    /// </summary>
+    public static Task<string> ApplyFixAllAsync(
+        DiagnosticAnalyzer analyzer,
+        CodeFixProvider codeFix,
+        string source,
         bool useLegacyReferences = true
-    ) => ApplyFixCoreAsync(analyzer, codeFix, source, useLegacyReferences);
+    ) => ApplyFixAllCoreAsync(analyzer, codeFix, source, useLegacyReferences);
 
     private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsCoreAsync(
         DiagnosticAnalyzer analyzer,
@@ -52,7 +65,8 @@ internal static class AnalyzerVerifier
         DiagnosticAnalyzer analyzer,
         CodeFixProvider codeFix,
         string source,
-        bool useLegacyReferences
+        bool useLegacyReferences,
+        int expectedDiagnosticCount
     )
     {
         using var workspace = new AdhocWorkspace();
@@ -75,7 +89,17 @@ internal static class AnalyzerVerifier
             .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
             .ConfigureAwait(false);
 
-        var diagnostic = diagnostics.Single();
+        if (diagnostics.Length != expectedDiagnosticCount)
+        {
+            throw new InvalidOperationException(
+                $"Expected {expectedDiagnosticCount} diagnostic(s) but found {diagnostics.Length}."
+            );
+        }
+
+        // Only the first diagnostic is fixed here; callers that pass expectedDiagnosticCount > 1 (to test a fix
+        // applied to one site among several matches) still only exercise the first one. Exercising every matched
+        // site in one go requires ApplyFixAllAsync instead.
+        var diagnostic = diagnostics[0];
 
         CodeAction? registeredAction = null;
         var fixContext = new CodeFixContext(
@@ -98,6 +122,134 @@ internal static class AnalyzerVerifier
         var newRoot = await newDocument.GetSyntaxRootAsync().ConfigureAwait(false);
 
         return newRoot!.ToFullString();
+    }
+
+    private static async Task<string> ApplyFixAllCoreAsync(
+        DiagnosticAnalyzer analyzer,
+        CodeFixProvider codeFix,
+        string source,
+        bool useLegacyReferences
+    )
+    {
+        using var workspace = new AdhocWorkspace();
+
+        var initialProject = workspace.AddProject("TestProject", LanguageNames.CSharp);
+        var configuredProject = initialProject
+            .WithMetadataReferences(useLegacyReferences ? LegacyReferences.Value : ModernReferences)
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        if (!workspace.TryApplyChanges(configuredProject.Solution))
+        {
+            throw new InvalidOperationException("Failed to apply project configuration to the workspace.");
+        }
+
+        var document = workspace.AddDocument(configuredProject.Id, "Test.cs", SourceText.From(source));
+
+        var diagnostics = await GetAnalyzerDiagnosticsAsync(document, analyzer, CancellationToken.None)
+            .ConfigureAwait(false);
+
+        if (diagnostics.Length < 2)
+        {
+            throw new InvalidOperationException(
+                "Expected at least two diagnostics to exercise the Fix All / Batch Fixer code path."
+            );
+        }
+
+        var equivalenceKey = await GetEquivalenceKeyAsync(document, codeFix, diagnostics[0]).ConfigureAwait(false);
+
+        var fixAllProvider =
+            codeFix.GetFixAllProvider()
+            ?? throw new InvalidOperationException("The code fix provider does not support Fix All.");
+
+        var fixAllContext = new FixAllContext(
+            document,
+            codeFix,
+            FixAllScope.Document,
+            equivalenceKey,
+            codeFix.FixableDiagnosticIds,
+            new AnalyzerFixAllDiagnosticProvider(analyzer),
+            CancellationToken.None
+        );
+
+        var fixAllAction =
+            await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("No Fix All action was registered.");
+
+        var operations = await fixAllAction.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+        var applyChanges = operations.OfType<ApplyChangesOperation>().Single();
+        var newDocument = applyChanges.ChangedSolution.GetDocument(document.Id)!;
+        var newRoot = await newDocument.GetSyntaxRootAsync().ConfigureAwait(false);
+
+        return newRoot!.ToFullString();
+    }
+
+    private static async Task<string?> GetEquivalenceKeyAsync(
+        Document document,
+        CodeFixProvider codeFix,
+        Diagnostic diagnostic
+    )
+    {
+        CodeAction? registeredAction = null;
+        var fixContext = new CodeFixContext(
+            document,
+            diagnostic,
+            (action, _) => registeredAction ??= action,
+            CancellationToken.None
+        );
+
+        await codeFix.RegisterCodeFixesAsync(fixContext).ConfigureAwait(false);
+
+        return registeredAction?.EquivalenceKey;
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetAnalyzerDiagnosticsAsync(
+        Document document,
+        DiagnosticAnalyzer analyzer,
+        CancellationToken cancellationToken
+    )
+    {
+        var compilation = (CSharpCompilation)
+            (await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false))!;
+        var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer));
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Feeds the analyzer's own diagnostics back into the Fix All engine, since the in-memory test project has no diagnostics of its own otherwise.</summary>
+    private sealed class AnalyzerFixAllDiagnosticProvider(DiagnosticAnalyzer analyzer)
+        : FixAllContext.DiagnosticProvider
+    {
+        public override async Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(
+            Project project,
+            CancellationToken cancellationToken
+        )
+        {
+            var diagnostics = ImmutableArray<Diagnostic>.Empty;
+
+            foreach (var document in project.Documents)
+            {
+                diagnostics = diagnostics.AddRange(
+                    await GetAnalyzerDiagnosticsAsync(document, analyzer, cancellationToken).ConfigureAwait(false)
+                );
+            }
+
+            return diagnostics;
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(
+            Document document,
+            CancellationToken cancellationToken
+        ) => GetAllDiagnosticsForDocumentAsync(document, cancellationToken);
+
+        public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(
+            Project project,
+            CancellationToken cancellationToken
+        ) => GetAllDiagnosticsAsync(project, cancellationToken);
+
+        private async Task<IEnumerable<Diagnostic>> GetAllDiagnosticsForDocumentAsync(
+            Document document,
+            CancellationToken cancellationToken
+        ) => await GetAnalyzerDiagnosticsAsync(document, analyzer, cancellationToken).ConfigureAwait(false);
     }
 
     private static CSharpCompilation CreateCompilation(string source, bool useLegacyReferences)

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs
@@ -31,7 +31,20 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains("ArgumentException.ThrowIfContainsWhiteSpace(argument);");
+        const string expected = """
+            using System;
+            using System.Linq;
+
+            class C
+            {
+                void M(string argument)
+                {
+                    ArgumentException.ThrowIfContainsWhiteSpace(argument);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfCountAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfCountAnalyzerTests.cs
@@ -37,7 +37,21 @@ public sealed class ThrowIfCountAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains($"ArgumentException.{expectedInvocation}");
+        var expected = $$"""
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            class C
+            {
+                void M(ICollection<int> argument)
+                {
+                    ArgumentException.{{expectedInvocation}}
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDefaultAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDefaultAnalyzerTests.cs
@@ -169,7 +169,19 @@ public sealed class ThrowIfDefaultAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains("ArgumentException.ThrowIfDefault(argument);");
+        const string expected = """
+            using System;
+
+            class C
+            {
+                void M(Guid argument)
+                {
+                    ArgumentException.ThrowIfDefault(argument);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDisposedAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfDisposedAnalyzerTests.cs
@@ -234,6 +234,20 @@ public sealed class ThrowIfDisposedAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains("ObjectDisposedException.ThrowIf(_disposed, this);");
+        const string expected = """
+            using System;
+
+            class C
+            {
+                private bool _disposed;
+
+                void M()
+                {
+                    ObjectDisposedException.ThrowIf(_disposed, this);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfEmptyGuidAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfEmptyGuidAnalyzerTests.cs
@@ -150,6 +150,18 @@ public sealed class ThrowIfEmptyGuidAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains("ArgumentException.ThrowIfEmptyGuid(argument);");
+        const string expected = """
+            using System;
+
+            class C
+            {
+                void M(Guid argument)
+                {
+                    ArgumentException.ThrowIfEmptyGuid(argument);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfLengthAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfLengthAnalyzerTests.cs
@@ -34,7 +34,19 @@ public sealed class ThrowIfLengthAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains($"ArgumentException.{expectedInvocation}");
+        var expected = $$"""
+            using System;
+
+            class C
+            {
+                void M(string argument)
+                {
+                    ArgumentException.{{expectedInvocation}}
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullAnalyzerTests.cs
@@ -972,4 +972,46 @@ public sealed class ThrowIfNullAnalyzerTests
         _ = await Assert.That(fixedSource).Contains("using System;");
         _ = await Assert.That(fixedSource).Contains("ArgumentNullException.ThrowIfNull(argument);");
     }
+
+    [Test]
+    public async Task CodeFix_WhenFixAllAppliedAcrossTwoMatchedSites_ReplacesBothWithThrowIfNullCalls()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? first, string? second)
+                {
+                    if (first is null) throw new ArgumentNullException(nameof(first));
+                    if (second is null) throw new ArgumentNullException(nameof(second));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(2);
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAllAsync(
+            new ThrowIfNullAnalyzer(),
+            new ThrowIfNullCodeFixProvider(),
+            source
+        );
+
+        const string expected = """
+            using System;
+
+            class C
+            {
+                void M(string? first, string? second)
+                {
+                    ArgumentNullException.ThrowIfNull(first);
+                    ArgumentNullException.ThrowIfNull(second);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
+    }
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullOrEmptyAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullOrEmptyAnalyzerTests.cs
@@ -401,7 +401,19 @@ public sealed class ThrowIfNullOrEmptyAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains("ArgumentException.ThrowIfNullOrEmpty(argument);");
+        const string expected = """
+            using System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    ArgumentException.ThrowIfNullOrEmpty(argument);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]
@@ -425,6 +437,18 @@ public sealed class ThrowIfNullOrEmptyAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains("ArgumentException.ThrowIfNullOrWhiteSpace(argument);");
+        const string expected = """
+            using System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    ArgumentException.ThrowIfNullOrWhiteSpace(argument);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 }

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfOutOfRangeAnalyzerTests.cs
@@ -40,7 +40,19 @@ public sealed class ThrowIfOutOfRangeAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains($"ArgumentOutOfRangeException.{expectedInvocation}");
+        var expected = $$"""
+            using System;
+
+            class C
+            {
+                void M(int argument)
+                {
+                    ArgumentOutOfRangeException.{{expectedInvocation}}
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]
@@ -68,7 +80,19 @@ public sealed class ThrowIfOutOfRangeAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains("ArgumentOutOfRangeException.ThrowIfLessThan(argument, other);");
+        const string expected = """
+            using System;
+
+            class C
+            {
+                void M(int argument, int other)
+                {
+                    ArgumentOutOfRangeException.ThrowIfLessThan(argument, other);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]
@@ -161,7 +185,19 @@ public sealed class ThrowIfOutOfRangeAnalyzerTests
             source
         );
 
-        _ = await Assert.That(fixedSource).Contains("ArgumentOutOfRangeException.ThrowIfOutOfRange(argument, 5, 100);");
+        const string expected = """
+            using System;
+
+            class C
+            {
+                void M(int argument)
+                {
+                    ArgumentOutOfRangeException.ThrowIfOutOfRange(argument, 5, 100);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]


### PR DESCRIPTION
**Expected conflict:** other agents are concurrently adding tests to the nine `ThrowIf*AnalyzerTests.cs` files as part of the same finding-per-PR batch. This PR touches the shared harness (`AnalyzerVerifier.cs`) and the same nine test files, but the edits to the test files are mechanical (single-assertion replacements at known line numbers), so conflicts should be easy to resolve by re-applying on top of the other PRs, or vice versa.

## Defect

Eleven of thirteen `fixedSource` assertions across the nine `ThrowIf*AnalyzerTests.cs` files only checked that the expected invocation string appeared *somewhere* in the fixed document (`Contains`), never that the original `if (...) throw ...;` was actually gone. There was no second line of defense either: `ApplyFixCoreAsync` in `AnalyzerVerifier.cs` never recompiled or re-analyzed the fixed document, and `GetDiagnosticsCoreAsync` only ever runs against the pre-fix source.

Consequence: a code fix provider that inserted the throw-helper call while leaving the original `if (...) throw ...;` in place (compile-clean, duplicated validation) would have passed every existing test undetected.

There was also zero coverage of `WellKnownFixAllProviders.BatchFixer`, which all nine `CodeFixProvider`s declare and which the README advertises, because `ApplyFixCoreAsync` used `diagnostics.Single()` and so could never run against a source with more than one matched site.

## Changes (test-only, no `src/` changes)

1. **`tests/NetEvolve.Arguments.Analyser.Tests.Unit/AnalyzerVerifier.cs`**
   - `ApplyFixAsync`/`ApplyFixCoreAsync` now take an explicit `expectedDiagnosticCount` (default `1`), replacing the previous `diagnostics.Single()`. The default preserves prior strictness for every existing call site; it only becomes relevant when a caller explicitly wants to exercise a single-site fix against a source containing more than one diagnostic.
   - Added `ApplyFixAllAsync` plus a private `AnalyzerFixAllDiagnosticProvider` (`FixAllContext.DiagnosticProvider`) that re-runs the analyzer per document/project, so tests can drive `codeFix.GetFixAllProvider()` (i.e. `WellKnownFixAllProviders.BatchFixer`) end-to-end.

2. **Nine `ThrowIf*AnalyzerTests.cs` files** — replaced the eleven `Contains`-only `fixedSource` assertions with full expected-document `IsEqualTo` comparisons (verified by running the suite after each file): `ThrowIfLengthAnalyzerTests.cs`, `ThrowIfCountAnalyzerTests.cs`, `ThrowIfContainsWhiteSpaceAnalyzerTests.cs`, `ThrowIfDefaultAnalyzerTests.cs`, `ThrowIfDisposedAnalyzerTests.cs`, `ThrowIfEmptyGuidAnalyzerTests.cs`, `ThrowIfNullOrEmptyAnalyzerTests.cs` (x2), `ThrowIfOutOfRangeAnalyzerTests.cs` (x3).

3. **`ThrowIfNullAnalyzerTests.cs`** — added `CodeFix_WhenFixAllAppliedAcrossTwoMatchedSites_ReplacesBothWithThrowIfNullCalls`, a new test exercising `ApplyFixAllAsync` against a source with two independent null-check sites, giving `WellKnownFixAllProviders.BatchFixer` its first coverage.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — green.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 104/104 green (was 103 before this PR added one test).
- Manually confirmed the tightened assertions actually catch the defect class: temporarily changed `ThrowIfDefaultCodeFixProvider.ApplyFixAsync` to insert the helper call via `InsertNodesBefore` instead of replacing the `if` statement (leaving the original throw in place). `CodeFix_WhenApplied_ReplacesWithThrowIfDefaultCall` failed as expected; reverted before committing.

## Not attempted (explicitly out of scope for this PR)

- **A "fixed source has no `DiagnosticSeverity.Error`" assertion is not implementable as the harness stands.** `CreateLegacyReferences` (`AnalyzerVerifier.cs`) supplies only `netstandard.dll` and never references the `NetEvolve.Arguments` polyfill assembly, so every existing fix test's fixed source would immediately emit `CS0117` (no such member) if compiled. This is the highest-value follow-up: add a `NetEvolve.Arguments` reference to the legacy reference set so fixed sources can be recompiled and asserted error-free.
- **Receiver types are pinned per rule** — every NEA0004/NEA0009 source uses a `Guid` parameter, every NEA0006 source a `string`, every NEA0007 source an `ICollection<int>` — which is precisely why the receiver-type defect class was structurally invisible in this suite. Other PRs in this batch are adding the corresponding negative cases; not addressed here since it's outside this PR's assertion-tightening / harness scope.
