### PR TITLE
fix(packaging): ship analyzers inside the NetEvolve.Arguments package

### DIFF
--- a/src/NetEvolve.Arguments/NetEvolve.Arguments.csproj
+++ b/src/NetEvolve.Arguments/NetEvolve.Arguments.csproj
@@ -10,6 +10,15 @@
     <PackageReleaseNotes>$(PackageProjectUrl)/releases/</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NetEvolve.Arguments.Analyser\NetEvolve.Arguments.Analyser.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <!-- OutputItemType="Analyzer" keeps this project linting itself with its own analyser during
+         local builds; ReferenceOutputAssembly="false" means it is a build-order dependency only and
+         is never a compile-time or NuGet dependency - its DLL is packed directly below instead. -->
+    <ProjectReference Include="..\NetEvolve.Arguments.Analyser\NetEvolve.Arguments.Analyser.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Not TFM-specific: evaluated once by the outer (cross-targeting) build, so the analyser DLL
+         ends up exactly once under analyzers/dotnet/cs regardless of how many TargetFrameworks this
+         project builds for. The analyser project only ever produces a netstandard2.0 output. -->
+    <None Include="..\NetEvolve.Arguments.Analyser\bin\$(Configuration)\netstandard2.0\NetEvolve.Arguments.Analyser.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 </Project>

--- a/src/NetEvolve.Arguments/NetEvolve.Arguments.csproj
+++ b/src/NetEvolve.Arguments/NetEvolve.Arguments.csproj
@@ -10,10 +10,12 @@
     <PackageReleaseNotes>$(PackageProjectUrl)/releases/</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
-    <!-- OutputItemType="Analyzer" keeps this project linting itself with its own analyser during
-         local builds; ReferenceOutputAssembly="false" means it is a build-order dependency only and
-         is never a compile-time or NuGet dependency - its DLL is packed directly below instead. -->
-    <ProjectReference Include="..\NetEvolve.Arguments.Analyser\NetEvolve.Arguments.Analyser.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="All" />
+    <!-- This reference exists purely to guarantee build order, so the analyser DLL is present on
+         disk at the path the <None Pack="true"> item below points at. ReferenceOutputAssembly="false"
+         means it is never a compile-time or NuGet dependency. The analyzer is deliberately NOT applied
+         to this project itself (no OutputItemType="Analyzer") - self-analysis is intentionally disabled
+         here per the owner's decision. -->
+    <ProjectReference Include="..\NetEvolve.Arguments.Analyser\NetEvolve.Arguments.Analyser.csproj" ReferenceOutputAssembly="false" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <!-- Not TFM-specific: evaluated once by the outer (cross-targeting) build, so the analyser DLL


### PR DESCRIPTION
## Decision

Consumers of `NetEvolve.Arguments` should get the NEA0001-NEA0009 analyzers automatically. Two dependency-flow approaches were measured against the real produced nuspec across all 9 target frameworks (`net472`, `net48`, `net481`, `netstandard2.0`, `net6.0`, `net7.0`, `net8.0`, `net9.0`, `net10.0`) and both dead-ended:

1. `<ProjectReference ... PrivateAssets="None" />` (no `ReferenceOutputAssembly`): the nuspec correctly gets a `<dependency id="NetEvolve.Arguments.Analyser" ...>` entry, but the `ProjectReference` becomes a real compile-time reference, and `net6.0`/`net7.0`/`net8.0`/`net9.0` **fail to build** with `MSB3277` (`System.Collections.Immutable` version conflict pulled in transitively via Roslyn).
2. `<ProjectReference ... ReferenceOutputAssembly="false" PrivateAssets="None" />`: all 9 TFMs build cleanly, but **every** nuspec `<group>` is empty — `ReferenceOutputAssembly="false"` unconditionally suppresses the dependency entry, regardless of `PrivateAssets`.

This is a genuine either/or: no combination of these two `ProjectReference` attributes gets both a working multi-target build and a flowed package dependency.

**Chosen approach:** don't ship the analyzer as a NuGet dependency at all. Instead, pack the `NetEvolve.Arguments.Analyser` DLL directly into the `NetEvolve.Arguments` package under `analyzers/dotnet/cs/`. Consumers get the analyzers from the single `NetEvolve.Arguments` package reference, with no second package to resolve and no version-conflict surface.

## Implementation

`src/NetEvolve.Arguments/NetEvolve.Arguments.csproj` (only file changed):

```xml
<ItemGroup>
  <!-- This reference exists purely to guarantee build order, so the analyser DLL is present on
       disk at the path the <None Pack="true"> item below points at. ReferenceOutputAssembly="false"
       means it is never a compile-time or NuGet dependency. The analyzer is deliberately NOT applied
       to this project itself (no OutputItemType="Analyzer") - self-analysis is intentionally disabled
       here per the owner's decision. -->
  <ProjectReference Include="..\NetEvolve.Arguments.Analyser\NetEvolve.Arguments.Analyser.csproj" ReferenceOutputAssembly="false" PrivateAssets="All" />
</ItemGroup>
<ItemGroup>
  <!-- Not TFM-specific: evaluated once by the outer (cross-targeting) build, so the analyser DLL
       ends up exactly once under analyzers/dotnet/cs regardless of how many TargetFrameworks this
       project builds for. The analyser project only ever produces a netstandard2.0 output. -->
  <None Include="..\NetEvolve.Arguments.Analyser\bin\$(Configuration)\netstandard2.0\NetEvolve.Arguments.Analyser.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
</ItemGroup>
```

Notes on the mechanics:
- `main`'s `ProjectReference` previously carried `OutputItemType="Analyzer"`, which applied the analyser to `NetEvolve.Arguments` itself during local builds (self-dogfooding). **That is deliberately removed here**: `NetEvolve.Arguments` must not be analyzed by its own analyzer — this was an explicit owner decision, not up for engineering re-litigation. The `ProjectReference` is kept only for build ordering (`ReferenceOutputAssembly="false"`, `PrivateAssets="All"`), so the analyser DLL exists on disk before packing.
- The packing `<None>` item is declared as a plain (non-TFM-conditioned) item, so it is evaluated once by the outer/cross-targeting build rather than once per inner TFM build — this is what keeps the DLL from being added 9 times (once per TFM) to `analyzers/dotnet/cs`. Verified empirically below.
- The path is a hardcoded `bin\$(Configuration)\netstandard2.0\...` (the analyser only ever has one TFM, `netstandard2.0`, so this is stable) rather than resolved via MSBuild reference-assembly APIs, favoring a working, clearly-commented path over a cleverer one.

## Verification

**Build — all 9 TFMs, 0 errors, 0 warnings, no MSB3277:**

```
$ dotnet build src/NetEvolve.Arguments/NetEvolve.Arguments.csproj -c Release
...
NetEvolve.Arguments.Analyser -> ...\src\NetEvolve.Arguments.Analyser\bin\Release\netstandard2.0\NetEvolve.Arguments.Analyser.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\net7.0\NetEvolve.Arguments.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\net472\NetEvolve.Arguments.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\net9.0\NetEvolve.Arguments.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\net8.0\NetEvolve.Arguments.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\net481\NetEvolve.Arguments.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\net48\NetEvolve.Arguments.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\netstandard2.0\NetEvolve.Arguments.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\net10.0\NetEvolve.Arguments.dll
NetEvolve.Arguments -> ...\src\NetEvolve.Arguments\bin\Release\net6.0\NetEvolve.Arguments.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

**Pack, then listed the produced nupkg (it is a zip):**

```
$ dotnet pack src/NetEvolve.Arguments/NetEvolve.Arguments.csproj -c Release -o ./local-pack-verify
...
Successfully created package '...\local-pack-verify\NetEvolve.Arguments.1.0.0.nupkg'.
```

nupkg entries (full listing):

```
analyzers/dotnet/cs/NetEvolve.Arguments.Analyser.dll
lib/net10.0/NetEvolve.Arguments.dll
lib/net10.0/NetEvolve.Arguments.xml
lib/net472/NetEvolve.Arguments.dll
lib/net472/NetEvolve.Arguments.xml
lib/net48/NetEvolve.Arguments.dll
lib/net48/NetEvolve.Arguments.xml
lib/net481/NetEvolve.Arguments.dll
lib/net481/NetEvolve.Arguments.xml
lib/net6.0/NetEvolve.Arguments.dll
lib/net6.0/NetEvolve.Arguments.xml
lib/net7.0/NetEvolve.Arguments.dll
lib/net7.0/NetEvolve.Arguments.xml
lib/net8.0/NetEvolve.Arguments.dll
lib/net8.0/NetEvolve.Arguments.xml
lib/net9.0/NetEvolve.Arguments.dll
lib/net9.0/NetEvolve.Arguments.xml
lib/netstandard2.0/NetEvolve.Arguments.dll
lib/netstandard2.0/NetEvolve.Arguments.xml
NetEvolve.Arguments.nuspec
README.md
```

Confirmed:
- Exactly **one** `analyzers/dotnet/cs/NetEvolve.Arguments.Analyser.dll` (not once per TFM).
- All 9 `lib/<tfm>/NetEvolve.Arguments.dll` entries present.
- `NetEvolve.Arguments.nuspec` `<dependencies>` has an empty `<group>` for every TFM — **no** `NetEvolve.Arguments.Analyser` dependency entry anywhere, which is now intentional:

```xml
<dependencies>
  <group targetFramework="net10.0" />
  <group targetFramework=".NETFramework4.7.2" />
  <group targetFramework=".NETFramework4.8" />
  <group targetFramework=".NETFramework4.8.1" />
  <group targetFramework="net6.0" />
  <group targetFramework="net7.0" />
  <group targetFramework="net8.0" />
  <group targetFramework="net9.0" />
  <group targetFramework=".NETStandard2.0" />
</dependencies>
```

(Note: in this repo/SDK, `dotnet pack` alone does not implicitly trigger a build — this is pre-existing behavior, reproducible identically on the untouched, already-merged `NetEvolve.Arguments.Analyser` project, not something this change introduces. Verification above always builds first, then packs, matching how CI is expected to run these two steps.)

**Build ordering re-verified from a clean state**, after removing `OutputItemType="Analyzer"`: deleted both projects' `bin`/`obj` folders, confirmed the analyser's `bin` was actually gone, then ran a single `dotnet build src/NetEvolve.Arguments/NetEvolve.Arguments.csproj -c Release`. Output confirms the analyser project builds first (`NetEvolve.Arguments.Analyser -> ...\bin\Release\netstandard2.0\NetEvolve.Arguments.Analyser.dll`), before any of the 9 `NetEvolve.Arguments` TFM outputs — the `ProjectReference` still enforces build order correctly even with `OutputItemType="Analyzer"` gone. Packing from that build again produced exactly one `analyzers/dotnet/cs/NetEvolve.Arguments.Analyser.dll` in the nupkg and no dependency entries.

**Self-analysis confirmed disabled:** ran `dotnet build src/NetEvolve.Arguments/NetEvolve.Arguments.csproj -c Release --no-incremental -v normal` (full rebuild, verbose) and grepped the entire output for `NEA00` — zero matches. `NetEvolve.Arguments` no longer sees its own analyzer's diagnostics.

**Tests:** `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 106/106 passed, 0 failed, 0 skipped.

`./local-pack-verify` was deleted before committing and is not part of this branch.

## Open question for the owner

`main` already contains merged #738, which made the `NetEvolve.Arguments.Analyser` project pack correctly to `analyzers/dotnet/cs` as its **own**, standalone package. With this PR, that standalone package becomes redundant for consumers of `NetEvolve.Arguments` — anyone taking a dependency on `NetEvolve.Arguments` already gets the analyzers bundled in. Worth reconsidering whether `NetEvolve.Arguments.Analyser` should still be published as its own NuGet package going forward, or kept internal-only/unlisted. Not changed here — #738 and the analyser `.csproj` are left as-is; this is raised as a question, not acted on.
