### PR TITLE
feat(analyser): recognize Count and Where/Any whitespace checks in NEA0008

### DIFF
--- a/docs/analysers/NEA0008.md
+++ b/docs/analysers/NEA0008.md
@@ -17,10 +17,14 @@ Code checks whether a string contains any white-space character and then conditi
 
 There is no built-in Roslyn analyzer for this pattern — `ArgumentException.ThrowIfContainsWhiteSpace` is a throw-helper provided by [NetEvolve.Arguments](https://www.nuget.org/packages/NetEvolve.Arguments/) itself, not the BCL, so this rule always fires regardless of target framework.
 
-Recognized shapes:
+Recognized shapes (both the method-group form `char.IsWhiteSpace` and the equivalent lambda `c => char.IsWhiteSpace(c)` are accepted as the predicate in every shape below):
 
 - `if (arg.Any(c => char.IsWhiteSpace(c))) throw new ArgumentException(...);`
 - `if (arg.Any(char.IsWhiteSpace)) throw new ArgumentException(...);`
+- `if (arg.Count(char.IsWhiteSpace) > 0) throw new ArgumentException(...);` (also `>= 1` and `!= 0`, and the operand-swapped forms, e.g. `if (0 < arg.Count(char.IsWhiteSpace)) ...`)
+- `if (arg.Where(char.IsWhiteSpace).Any()) throw new ArgumentException(...);`
+
+Every shape is only reported when the receiver (`arg`) is a `string` and the matched `Any`/`Count`/`Where` invocation resolves to `System.Linq.Enumerable`. Other comparisons against `Count(...)`, such as `> 1` or `== 0`, are not equivalent to "contains white space" and are not recognized.
 
 ## Example
 

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceAnalyzer.cs
@@ -38,7 +38,10 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzer : DiagnosticAnalyzer
     {
         var ifStatement = (IfStatementSyntax)context.Node;
 
-        if (!TryGetContainsWhiteSpaceTarget(ifStatement.Condition, out var argument) || argument is null)
+        if (
+            !TryGetContainsWhiteSpaceTarget(ifStatement.Condition, out var argument, out var invocationsToVerify)
+            || argument is null
+        )
         {
             return;
         }
@@ -71,15 +74,19 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (
-            !IsLinqEnumerableAny(
-                (InvocationExpressionSyntax)SyntaxHelpers.Unwrap(ifStatement.Condition),
-                context.SemanticModel,
-                context.CancellationToken
-            )
-        )
+        foreach (var (invocation, expectedMethodName) in invocationsToVerify)
         {
-            return;
+            if (
+                !IsLinqEnumerableMethod(
+                    invocation,
+                    expectedMethodName,
+                    context.SemanticModel,
+                    context.CancellationToken
+                )
+            )
+            {
+                return;
+            }
         }
 
         context.ReportDiagnostic(
@@ -91,14 +98,66 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzer : DiagnosticAnalyzer
         );
     }
 
-    /// <summary>Recognizes <c>arg.Any(c => char.IsWhiteSpace(c))</c> and the method-group form <c>arg.Any(char.IsWhiteSpace)</c>.</summary>
+    /// <summary>
+    /// Recognizes the white-space-check shapes supported by this rule:
+    /// <list type="bullet">
+    /// <item><description><c>arg.Any(c => char.IsWhiteSpace(c))</c> and the method-group form <c>arg.Any(char.IsWhiteSpace)</c>.</description></item>
+    /// <item><description><c>arg.Count(char.IsWhiteSpace) &gt; 0</c>, <c>&gt;= 1</c> and <c>!= 0</c> (and the operand-swapped forms, e.g. <c>0 &lt; arg.Count(char.IsWhiteSpace)</c>).</description></item>
+    /// <item><description><c>arg.Where(char.IsWhiteSpace).Any()</c>.</description></item>
+    /// </list>
+    /// </summary>
     /// <param name="condition">The <c>if</c> statement's condition expression.</param>
     /// <param name="argument">When this method returns <see langword="true"/>, the string argument being checked; otherwise, <see langword="null"/>.</param>
+    /// <param name="invocationsToVerify">
+    /// When this method returns <see langword="true"/>, the invocation(s) that must still be confirmed (via the
+    /// semantic model) to resolve to the corresponding <see cref="System.Linq.Enumerable"/> method, paired with the
+    /// expected method name; otherwise, empty.
+    /// </param>
     /// <returns><see langword="true"/> if <paramref name="condition"/> is a recognized white-space-check shape; otherwise, <see langword="false"/>.</returns>
-    internal static bool TryGetContainsWhiteSpaceTarget(ExpressionSyntax condition, out ExpressionSyntax? argument)
+    internal static bool TryGetContainsWhiteSpaceTarget(
+        ExpressionSyntax condition,
+        out ExpressionSyntax? argument,
+        out ImmutableArray<(InvocationExpressionSyntax Invocation, string ExpectedMethodName)> invocationsToVerify
+    )
     {
         argument = null;
+        invocationsToVerify = ImmutableArray<(InvocationExpressionSyntax, string)>.Empty;
         condition = SyntaxHelpers.Unwrap(condition);
+
+        if (TryGetAnyShape(condition, out argument, out var anyInvocation))
+        {
+            invocationsToVerify = ImmutableArray.Create((anyInvocation!, "Any"));
+            return true;
+        }
+
+        if (TryGetCountShape(condition, out argument, out var countInvocation))
+        {
+            invocationsToVerify = ImmutableArray.Create((countInvocation!, "Count"));
+            return true;
+        }
+
+        if (TryGetWhereAnyShape(condition, out argument, out var whereInvocation, out var whereAnyInvocation))
+        {
+            invocationsToVerify = ImmutableArray.Create((whereInvocation!, "Where"), (whereAnyInvocation!, "Any"));
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Recognizes <c>arg.Any(c => char.IsWhiteSpace(c))</c> and the method-group form <c>arg.Any(char.IsWhiteSpace)</c>.</summary>
+    /// <param name="condition">The already-unwrapped condition expression.</param>
+    /// <param name="argument">When this method returns <see langword="true"/>, the string argument being checked; otherwise, <see langword="null"/>.</param>
+    /// <param name="invocation">When this method returns <see langword="true"/>, the matched <c>Any</c> invocation; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="condition"/> is the recognized <c>Any</c> shape; otherwise, <see langword="false"/>.</returns>
+    private static bool TryGetAnyShape(
+        ExpressionSyntax condition,
+        out ExpressionSyntax? argument,
+        out InvocationExpressionSyntax? invocation
+    )
+    {
+        argument = null;
+        invocation = null;
 
         if (
             condition
@@ -106,34 +165,183 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzer : DiagnosticAnalyzer
             {
                 Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: "Any" } access,
                 ArgumentList.Arguments.Count: 1,
-            } invocation
+            } anyInvocation
         )
         {
             return false;
         }
 
-        var predicate = SyntaxHelpers.Unwrap(invocation.ArgumentList.Arguments[0].Expression);
-
-        if (IsCharIsWhiteSpaceMemberAccess(predicate))
+        if (!IsWhiteSpacePredicate(anyInvocation.ArgumentList.Arguments[0].Expression))
         {
-            argument = access.Expression;
+            return false;
+        }
+
+        argument = access.Expression;
+        invocation = anyInvocation;
+        return true;
+    }
+
+    /// <summary>
+    /// Recognizes <c>arg.Count(char.IsWhiteSpace) &gt; 0</c>, <c>&gt;= 1</c> and <c>!= 0</c>, and the operand-swapped
+    /// forms (e.g. <c>0 &lt; arg.Count(char.IsWhiteSpace)</c>), all of which mean "at least one character matches".
+    /// </summary>
+    /// <param name="condition">The already-unwrapped condition expression.</param>
+    /// <param name="argument">When this method returns <see langword="true"/>, the string argument being checked; otherwise, <see langword="null"/>.</param>
+    /// <param name="invocation">When this method returns <see langword="true"/>, the matched <c>Count</c> invocation; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="condition"/> is the recognized <c>Count</c> comparison shape; otherwise, <see langword="false"/>.</returns>
+    private static bool TryGetCountShape(
+        ExpressionSyntax condition,
+        out ExpressionSyntax? argument,
+        out InvocationExpressionSyntax? invocation
+    )
+    {
+        argument = null;
+        invocation = null;
+
+        if (condition is not BinaryExpressionSyntax binary)
+        {
+            return false;
+        }
+
+        var left = SyntaxHelpers.Unwrap(binary.Left);
+        var right = SyntaxHelpers.Unwrap(binary.Right);
+        var kind = binary.Kind();
+
+        if (TryGetCountInvocation(left, out var countInvocation) && MeansCountGreaterThanZero(kind, right))
+        {
+            invocation = countInvocation;
+        }
+        else if (TryGetCountInvocation(right, out countInvocation) && MeansZeroLessThanCount(kind, left))
+        {
+            invocation = countInvocation;
+        }
+        else
+        {
+            return false;
+        }
+
+        if (!IsWhiteSpacePredicate(invocation!.ArgumentList.Arguments[0].Expression))
+        {
+            invocation = null;
+            return false;
+        }
+
+        argument = ((MemberAccessExpressionSyntax)invocation.Expression).Expression;
+        return true;
+    }
+
+    /// <summary>Recognizes a single-argument <c>.Count(predicate)</c> LINQ extension method invocation.</summary>
+    /// <param name="expression">The already-unwrapped expression to test.</param>
+    /// <param name="invocation">When this method returns <see langword="true"/>, the matched invocation; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="expression"/> is a recognized <c>Count(predicate)</c> shape; otherwise, <see langword="false"/>.</returns>
+    private static bool TryGetCountInvocation(ExpressionSyntax expression, out InvocationExpressionSyntax? invocation)
+    {
+        if (
+            expression is InvocationExpressionSyntax
+            {
+                Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: "Count" },
+                ArgumentList.Arguments.Count: 1,
+            } countInvocation
+        )
+        {
+            invocation = countInvocation;
             return true;
         }
 
+        invocation = null;
+        return false;
+    }
+
+    /// <summary>Determines whether <c>Count(...) kind rhs</c> means "at least one", i.e. <c>&gt; 0</c>, <c>&gt;= 1</c> or <c>!= 0</c>.</summary>
+    private static bool MeansCountGreaterThanZero(SyntaxKind kind, ExpressionSyntax rhs) =>
+        (kind == SyntaxKind.GreaterThanExpression && IsIntegerLiteral(rhs, 0))
+        || (kind == SyntaxKind.GreaterThanOrEqualExpression && IsIntegerLiteral(rhs, 1))
+        || (kind == SyntaxKind.NotEqualsExpression && IsIntegerLiteral(rhs, 0));
+
+    /// <summary>Determines whether <c>lhs kind Count(...)</c> means "at least one", i.e. <c>0 &lt; ...</c>, <c>1 &lt;= ...</c> or <c>0 != ...</c>.</summary>
+    private static bool MeansZeroLessThanCount(SyntaxKind kind, ExpressionSyntax lhs) =>
+        (kind == SyntaxKind.LessThanExpression && IsIntegerLiteral(lhs, 0))
+        || (kind == SyntaxKind.LessThanOrEqualExpression && IsIntegerLiteral(lhs, 1))
+        || (kind == SyntaxKind.NotEqualsExpression && IsIntegerLiteral(lhs, 0));
+
+    /// <summary>Determines whether an expression is an integer literal equal to <paramref name="value"/>.</summary>
+    /// <param name="expression">The already-unwrapped expression to test.</param>
+    /// <param name="value">The expected integer value.</param>
+    /// <returns><see langword="true"/> if <paramref name="expression"/> is an integer literal equal to <paramref name="value"/>; otherwise, <see langword="false"/>.</returns>
+    private static bool IsIntegerLiteral(ExpressionSyntax expression, int value) =>
+        SyntaxHelpers.Unwrap(expression) is LiteralExpressionSyntax { Token.Value: int literalValue }
+        && literalValue == value;
+
+    /// <summary>Recognizes <c>arg.Where(char.IsWhiteSpace).Any()</c>, with a parameterless <c>Any()</c> call.</summary>
+    /// <param name="condition">The already-unwrapped condition expression.</param>
+    /// <param name="argument">When this method returns <see langword="true"/>, the string argument being checked; otherwise, <see langword="null"/>.</param>
+    /// <param name="whereInvocation">When this method returns <see langword="true"/>, the matched <c>Where</c> invocation; otherwise, <see langword="null"/>.</param>
+    /// <param name="anyInvocation">When this method returns <see langword="true"/>, the matched <c>Any</c> invocation; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="condition"/> is the recognized <c>Where(...).Any()</c> shape; otherwise, <see langword="false"/>.</returns>
+    private static bool TryGetWhereAnyShape(
+        ExpressionSyntax condition,
+        out ExpressionSyntax? argument,
+        out InvocationExpressionSyntax? whereInvocation,
+        out InvocationExpressionSyntax? anyInvocation
+    )
+    {
+        argument = null;
+        whereInvocation = null;
+        anyInvocation = null;
+
         if (
-            predicate is SimpleLambdaExpressionSyntax { ExpressionBody: { } body } lambda
+            condition
+            is not InvocationExpressionSyntax
+            {
+                Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: "Any" } anyAccess,
+                ArgumentList.Arguments.Count: 0,
+            } anyInvocationCandidate
+        )
+        {
+            return false;
+        }
+
+        if (
+            SyntaxHelpers.Unwrap(anyAccess.Expression)
+            is not InvocationExpressionSyntax
+            {
+                Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: "Where" } whereAccess,
+                ArgumentList.Arguments.Count: 1,
+            } whereInvocationCandidate
+        )
+        {
+            return false;
+        }
+
+        if (!IsWhiteSpacePredicate(whereInvocationCandidate.ArgumentList.Arguments[0].Expression))
+        {
+            return false;
+        }
+
+        argument = whereAccess.Expression;
+        whereInvocation = whereInvocationCandidate;
+        anyInvocation = anyInvocationCandidate;
+        return true;
+    }
+
+    /// <summary>Determines whether a predicate argument is <c>char.IsWhiteSpace</c> as a method group, or the equivalent lambda <c>c =&gt; char.IsWhiteSpace(c)</c>.</summary>
+    /// <param name="predicateArgument">The argument expression passed as the predicate.</param>
+    /// <returns><see langword="true"/> if <paramref name="predicateArgument"/> is a recognized white-space predicate; otherwise, <see langword="false"/>.</returns>
+    private static bool IsWhiteSpacePredicate(ExpressionSyntax predicateArgument)
+    {
+        var predicate = SyntaxHelpers.Unwrap(predicateArgument);
+
+        if (IsCharIsWhiteSpaceMemberAccess(predicate))
+        {
+            return true;
+        }
+
+        return predicate is SimpleLambdaExpressionSyntax { ExpressionBody: { } body } lambda
             && SyntaxHelpers.Unwrap(body)
                 is InvocationExpressionSyntax { Expression: var callee, ArgumentList.Arguments.Count: 1 } call
             && IsCharIsWhiteSpaceMemberAccess(callee)
             && SyntaxHelpers.Unwrap(call.ArgumentList.Arguments[0].Expression) is IdentifierNameSyntax paramRef
-            && paramRef.Identifier.Text == lambda.Parameter.Identifier.Text
-        )
-        {
-            argument = access.Expression;
-            return true;
-        }
-
-        return false;
+            && paramRef.Identifier.Text == lambda.Parameter.Identifier.Text;
     }
 
     /// <summary>
@@ -152,18 +360,21 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzer : DiagnosticAnalyzer
         CancellationToken cancellationToken
     ) => semanticModel.GetTypeInfo(receiver, cancellationToken).Type?.SpecialType == SpecialType.System_String;
 
-    /// <summary>Determines whether an invocation resolves to <see cref="System.Linq.Enumerable.Any{TSource}(System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, bool})"/>, rather than some other method named <c>Any</c>.</summary>
+    /// <summary>Determines whether an invocation resolves to the named method on <see cref="System.Linq.Enumerable"/> (e.g. <c>Any</c>, <c>Count</c> or <c>Where</c>), rather than some other method or extension of the same name.</summary>
     /// <param name="invocation">The invocation expression to inspect.</param>
+    /// <param name="expectedMethodName">The expected method name, e.g. <c>"Any"</c>, <c>"Count"</c> or <c>"Where"</c>.</param>
     /// <param name="semanticModel">The semantic model used to resolve the invoked method.</param>
     /// <param name="cancellationToken">The token used to cancel semantic-model lookups.</param>
-    /// <returns><see langword="true"/> if <paramref name="invocation"/> invokes <c>System.Linq.Enumerable.Any</c>; otherwise, <see langword="false"/>.</returns>
-    private static bool IsLinqEnumerableAny(
+    /// <returns><see langword="true"/> if <paramref name="invocation"/> invokes <c>System.Linq.Enumerable.{expectedMethodName}</c>; otherwise, <see langword="false"/>.</returns>
+    private static bool IsLinqEnumerableMethod(
         InvocationExpressionSyntax invocation,
+        string expectedMethodName,
         SemanticModel semanticModel,
         CancellationToken cancellationToken
     ) =>
         semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
-            is IMethodSymbol { Name: "Any", ContainingType: { } containingType }
+            is IMethodSymbol { ContainingType: { } containingType } method
+        && method.Name == expectedMethodName
         && containingType.ToDisplayString() == "System.Linq.Enumerable";
 
     /// <summary>Determines whether an expression is a <c>char.IsWhiteSpace</c> member access, either via the <c>char</c> keyword or the <c>Char</c> identifier.</summary>

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceCodeFixProvider.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfContainsWhiteSpaceCodeFixProvider.cs
@@ -71,7 +71,8 @@ public sealed class ThrowIfContainsWhiteSpaceCodeFixProvider : CodeFixProvider
             root is null
             || !ThrowIfContainsWhiteSpaceAnalyzer.TryGetContainsWhiteSpaceTarget(
                 ifStatement.Condition,
-                out var argument
+                out var argument,
+                out _
             )
             || argument is null
         )

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfContainsWhiteSpaceAnalyzerTests.cs
@@ -5,6 +5,17 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzerTests
     [Test]
     [Arguments("argument.Any(c => char.IsWhiteSpace(c))")]
     [Arguments("argument.Any(char.IsWhiteSpace)")]
+    [Arguments("argument.Count(c => char.IsWhiteSpace(c)) > 0")]
+    [Arguments("argument.Count(char.IsWhiteSpace) > 0")]
+    [Arguments("argument.Count(c => char.IsWhiteSpace(c)) >= 1")]
+    [Arguments("argument.Count(char.IsWhiteSpace) >= 1")]
+    [Arguments("argument.Count(c => char.IsWhiteSpace(c)) != 0")]
+    [Arguments("argument.Count(char.IsWhiteSpace) != 0")]
+    [Arguments("0 < argument.Count(char.IsWhiteSpace)")]
+    [Arguments("1 <= argument.Count(char.IsWhiteSpace)")]
+    [Arguments("0 != argument.Count(char.IsWhiteSpace)")]
+    [Arguments("argument.Where(c => char.IsWhiteSpace(c)).Any()")]
+    [Arguments("argument.Where(char.IsWhiteSpace).Any()")]
     public async Task Analyze_WhenWhiteSpaceCheckThrowsArgumentException_ReportsDiagnosticAndFixes(string condition)
     {
         var source = $$"""
@@ -77,6 +88,22 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzerTests
     [Arguments(
         "if (argument.Any(char.IsWhiteSpace)) throw new ArgumentException(\"has whitespace\", nameof(argument));"
     )]
+    [Arguments("if (argument.Count(char.IsWhiteSpace) > 0) throw new ArgumentException(nameof(other));")]
+    [Arguments(
+        "if (argument.Count(char.IsWhiteSpace) > 0) throw new ArgumentException(\"has whitespace\", nameof(argument));"
+    )]
+    [Arguments("if (argument.Where(char.IsWhiteSpace).Any()) throw new ArgumentException(nameof(other));")]
+    [Arguments(
+        "if (argument.Where(char.IsWhiteSpace).Any()) throw new ArgumentException(\"has whitespace\", nameof(argument));"
+    )]
+    [Arguments("if (argument.Count(char.IsWhiteSpace) > 1) throw new ArgumentException(nameof(argument));")]
+    [Arguments("if (argument.Count(char.IsWhiteSpace) == 0) throw new ArgumentException(nameof(argument));")]
+    [Arguments("if (argument.Count(char.IsWhiteSpace) < 1) throw new ArgumentException(nameof(argument));")]
+    [Arguments("if (1 < argument.Count(char.IsWhiteSpace)) throw new ArgumentException(nameof(argument));")]
+    [Arguments("if (argument.All(char.IsWhiteSpace)) throw new ArgumentException(nameof(argument));")]
+    [Arguments("if (argument.Count(c => c == ' ') > 0) throw new ArgumentException(nameof(argument));")]
+    [Arguments("if (argument.Select(c => c).Any()) throw new ArgumentException(nameof(argument));")]
+    [Arguments("if (argument.Where(c => c == ' ').Any()) throw new ArgumentException(nameof(argument));")]
     [Arguments(
         """
             if (argument.Any(char.IsWhiteSpace))
@@ -133,6 +160,34 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzerTests
     }
 
     [Test]
+    [Arguments("char[]", "chars.Count(char.IsWhiteSpace) > 0")]
+    [Arguments("System.Collections.Generic.List<char>", "chars.Count(char.IsWhiteSpace) > 0")]
+    [Arguments("char[]", "chars.Where(char.IsWhiteSpace).Any()")]
+    [Arguments("System.Collections.Generic.List<char>", "chars.Where(char.IsWhiteSpace).Any()")]
+    public async Task Analyze_WhenReceiverIsNotString_NewShapes_DoesNotReportDiagnostic(
+        string parameterType,
+        string condition
+    )
+    {
+        var source = $$"""
+            using System;
+            using System.Linq;
+
+            class C
+            {
+                void M({{parameterType}} chars)
+                {
+                    if ({{condition}}) throw new ArgumentException(nameof(chars));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfContainsWhiteSpaceAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task Analyze_WhenReceiverHasNoResolvableType_DoesNotReportDiagnostic()
     {
         // "Predicate" refers to the method group C.Predicate(char), which has no type of its own
@@ -160,11 +215,68 @@ public sealed class ThrowIfContainsWhiteSpaceAnalyzerTests
     }
 
     [Test]
+    [Arguments("argument.Count(char.IsWhiteSpace) > 0")]
+    [Arguments("argument.Where(char.IsWhiteSpace).Any()")]
+    public async Task Analyze_WhenCountOrWhereIsUserDefinedExtension_DoesNotReportDiagnostic(string condition)
+    {
+        var source = $$"""
+            using System;
+
+            static class MyExtensions
+            {
+                public static int Count(this string s, Func<char, bool> predicate) => 0;
+
+                public static string[] Where(this string s, Func<char, bool> predicate) => Array.Empty<string>();
+
+                public static bool Any(this string[] s) => false;
+            }
+
+            class C
+            {
+                void M(string argument)
+                {
+                    if ({{condition}}) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfContainsWhiteSpaceAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Analyze_WhenAnyIsUserDefinedExtensionOnWhereResult_DoesNotReportDiagnostic()
+    {
+        var source = """
+            using System;
+            using System.Linq;
+
+            static class MyExtensions
+            {
+                public static bool Any(this System.Collections.Generic.IEnumerable<char> s) => false;
+            }
+
+            class C
+            {
+                void M(string argument)
+                {
+                    if (argument.Where(char.IsWhiteSpace).Any()) throw new ArgumentException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfContainsWhiteSpaceAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task Analyze_WhenAnyResolutionIsAmbiguous_DoesNotReportDiagnostic()
     {
         // Two equally applicable extension methods named "Any" make the call ambiguous, so
         // SemanticModel.GetSymbolInfo(...).Symbol is null (CandidateReason.OverloadResolutionFailure).
-        // This exercises the "Symbol is IMethodSymbol" pattern failing in IsLinqEnumerableAny, as
+        // This exercises the "Symbol is IMethodSymbol" pattern failing in IsLinqEnumerableMethod, as
         // opposed to Analyze_WhenAnyIsNotLinqEnumerableAny_DoesNotReportDiagnostic, where the symbol
         // resolves unambiguously to a method whose containing type merely isn't Enumerable.
         var source = """


### PR DESCRIPTION
## Stacked on #739

This PR is stacked on #739 (`fix/nea0008-string-receiver-gate`) and must merge after it. The base is set to `main` so GitHub shows the combined diff; the diff specific to this PR is the second commit on the branch.

## Summary

Extends NEA0008 (`ThrowIfContainsWhiteSpaceAnalyzer`) to recognize two additional equivalent shapes for "this string contains white space", in addition to the existing `s.Any(char.IsWhiteSpace)` / `s.Any(c => char.IsWhiteSpace(c))`:

- `s.Count(char.IsWhiteSpace) > 0`, `>= 1` and `!= 0`, including the operand-swapped forms (`0 < s.Count(...)`, `1 <= s.Count(...)`, `0 != s.Count(...)`).
- `s.Where(char.IsWhiteSpace).Any()` (parameterless `Any()` on the result of `Where`).

Both new shapes accept the same predicate forms as the existing shape (method group `char.IsWhiteSpace` and the lambda `c => char.IsWhiteSpace(c)`), reusing the existing predicate-matching logic (`IsWhiteSpacePredicate`, factored out of the previous inline code) rather than duplicating it.

Deliberately out of scope (per rule owner decision): `s.Contains(' ')`, `s.IndexOfAny(...)`, `s.All(char.IsWhiteSpace)`, and any negation handling — none of these are semantically equivalent to "contains white space" or are otherwise out of NEA0008's current scope.

## Crash fix

`Analyze` previously did an unconditional `(InvocationExpressionSyntax)` cast of the unwrapped condition before validating the resolved LINQ symbol. That was only safe because the old `TryGetContainsWhiteSpaceTarget` exclusively matched an `InvocationExpressionSyntax` condition. The new `Count(...) > 0` shape has a `BinaryExpressionSyntax` condition, which would have thrown `InvalidCastException` inside the IDE.

Fixed by having `TryGetContainsWhiteSpaceTarget` report the matched invocation(s) via an `out` parameter (`ImmutableArray<(InvocationExpressionSyntax Invocation, string ExpectedMethodName)>`) instead of `Analyze` re-deriving an invocation from `ifStatement.Condition` with a cast. Every shape still verifies its invocation(s) resolve to the real `System.Linq.Enumerable` method (`Any`, `Count`, or `Where`) via `GetSymbolInfo` — never by identifier text alone. The `Where(...).Any()` shape verifies both invocations.

The code fix provider was updated only to pass `out _` for the new parameter; it already derived everything from `argument`, so it required no other change and works unmodified for the new shapes.

## NEA0007 overlap check

Read `ThrowIfCountAnalyzer.cs`: its `TryGetCountTarget` only matches a **parameterless** `.Count()` invocation (`ArgumentList.Arguments.Count: 0`). The new NEA0008 `Count(predicate)` shape always has exactly one argument, so no source can trigger both NEA0007 and NEA0008 simultaneously.

## Tests

Added to `ThrowIfContainsWhiteSpaceAnalyzerTests.cs`:
- Positive cases for `Count(...) > 0` / `>= 1` / `!= 0` (plus operand-swapped forms) and `Where(...).Any()`, each with both method-group and lambda predicates, including code-fix verification.
- Negative cases: `Count(...) > 1`, `Count(...) == 0`, `Count(...) < 1`, operand-swapped `1 < Count(...)`, mismatched predicates for `Count`/`Where`, non-`Where` receiver for `.Any()`, `All(...)`.
- Non-string receivers (`char[]`, `List<char>`) for both new shapes.
- User-defined `Count`/`Where`/`Any` extension methods that are not the LINQ ones.
- Regression coverage for the two pre-existing `Any` shapes.

Also kept the three tests added by #739's coverage follow-up (`Analyze_WhenAnyIsNotLinqEnumerableAny_DoesNotReportDiagnostic`, `Analyze_WhenReceiverHasNoResolvableType_DoesNotReportDiagnostic`, `Analyze_WhenAnyResolutionIsAmbiguous_DoesNotReportDiagnostic`) after rebasing onto the new tip of #739 — all three still pass against the refactored `TryGetContainsWhiteSpaceTarget`/`IsLinqEnumerableMethod`.

## Docs

Updated `docs/analysers/NEA0008.md` to document the new recognized shapes and the "only `> 0`/`>= 1`/`!= 0` mean 'at least one'" caveat. No new rule ID, so `AnalyzerReleases.*.md` was left untouched.

## Verification

- `dotnet build src/NetEvolve.Arguments.Analyser/NetEvolve.Arguments.Analyser.csproj` — succeeded, 0 warnings, 0 errors.
- `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit/NetEvolve.Arguments.Analyser.Tests.Unit.csproj` — 138/138 passed.
- Coverage pass on `ThrowIfContainsWhiteSpaceAnalyzer.cs`: 98.0% line, 94.4% branch. The only uncovered lines are pre-existing (an `ArgumentNullException` guard in `Initialize`, and the `Char` identifier branch of `IsCharIsWhiteSpaceMemberAccess`), not introduced by this change.