### PR TITLE
fix(analyser): NEA0002 flags ArgumentNullException on empty/whitespace checks

### DIFF
--- a/docs/analysers/NEA0002.md
+++ b/docs/analysers/NEA0002.md
@@ -11,7 +11,7 @@
 
 ## Cause
 
-Code checks whether a string is `null`/empty or `null`/empty/whitespace-only and then conditionally throws an [ArgumentException](https://learn.microsoft.com/dotnet/api/system.argumentexception).
+Code checks whether a string is `null`/empty or `null`/empty/whitespace-only and then conditionally throws an [ArgumentException](https://learn.microsoft.com/dotnet/api/system.argumentexception) (or, incorrectly for the empty/whitespace-only case, an [ArgumentNullException](https://learn.microsoft.com/dotnet/api/system.argumentnullexception)).
 
 ## Rule description
 
@@ -21,6 +21,10 @@ Recognized shapes:
 
 - `if (string.IsNullOrEmpty(arg)) throw new ArgumentException(...);` → `ArgumentException.ThrowIfNullOrEmpty(arg)`
 - `if (string.IsNullOrWhiteSpace(arg)) throw new ArgumentException(...);` → `ArgumentException.ThrowIfNullOrWhiteSpace(arg)`
+- `if (string.IsNullOrEmpty(arg)) throw new ArgumentNullException(...);` → `ArgumentException.ThrowIfNullOrEmpty(arg)`
+- `if (string.IsNullOrWhiteSpace(arg)) throw new ArgumentNullException(...);` → `ArgumentException.ThrowIfNullOrWhiteSpace(arg)`
+
+The `ArgumentNullException` shapes are also flagged (and fixed the same way) because throwing it for the empty/whitespace-only case is itself a bug: the argument isn't `null`, so the wrong exception type reaches callers.
 
 Any exception constructor arguments (including a custom message) are dropped by the fix, matching the upstream CA1511 fixer behavior.
 

--- a/src/NetEvolve.Arguments.Analyser/DiagnosticDescriptors.cs
+++ b/src/NetEvolve.Arguments.Analyser/DiagnosticDescriptors.cs
@@ -28,7 +28,7 @@ internal static class DiagnosticDescriptors
         category: "Maintainability",
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        description: "A string.IsNullOrEmpty/IsNullOrWhiteSpace check that throws ArgumentException can be replaced by the ArgumentException.ThrowIfNullOrEmpty/ThrowIfNullOrWhiteSpace throw-helper, which works on every target framework supported by NetEvolve.Arguments, including those that predate .NET 8.",
+        description: "A string.IsNullOrEmpty/IsNullOrWhiteSpace check that throws ArgumentException or ArgumentNullException can be replaced by the ArgumentException.ThrowIfNullOrEmpty/ThrowIfNullOrWhiteSpace throw-helper, which works on every target framework supported by NetEvolve.Arguments, including those that predate .NET 8.",
         helpLinkUri: $"{HelpLinkBase}/NEA0002.md"
     );
 

--- a/src/NetEvolve.Arguments.Analyser/ThrowIfNullOrEmptyAnalyzer.cs
+++ b/src/NetEvolve.Arguments.Analyser/ThrowIfNullOrEmptyAnalyzer.cs
@@ -14,6 +14,15 @@ public sealed class ThrowIfNullOrEmptyAnalyzer : DiagnosticAnalyzer
     /// <summary>The fully-qualified metadata name of <see cref="ArgumentException"/>.</summary>
     private const string ArgumentExceptionMetadataName = "System.ArgumentException";
 
+    /// <summary>The fully-qualified metadata name of <see cref="ArgumentNullException"/>.</summary>
+    /// <remarks>
+    /// Also accepted as the thrown type: an <c>IsNullOrEmpty</c>/<c>IsNullOrWhiteSpace</c> check that throws
+    /// <see cref="ArgumentNullException"/> instead of <see cref="ArgumentException"/> is itself a bug for the
+    /// whitespace-only/empty-but-non-null case, and the same throw-helper fix corrects both the maintainability
+    /// concern and the wrong exception type.
+    /// </remarks>
+    private const string ArgumentNullExceptionMetadataName = "System.ArgumentNullException";
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(DiagnosticDescriptors.ThrowIfNullOrEmpty);
@@ -91,12 +100,21 @@ public sealed class ThrowIfNullOrEmptyAnalyzer : DiagnosticAnalyzer
         }
 
         if (
-            !SyntaxHelpers.TryGetThrownException(
-                ifStatement,
-                context.SemanticModel,
-                ArgumentExceptionMetadataName,
-                context.CancellationToken,
-                out var objectCreation
+            !(
+                SyntaxHelpers.TryGetThrownException(
+                    ifStatement,
+                    context.SemanticModel,
+                    ArgumentExceptionMetadataName,
+                    context.CancellationToken,
+                    out var objectCreation
+                )
+                || SyntaxHelpers.TryGetThrownException(
+                    ifStatement,
+                    context.SemanticModel,
+                    ArgumentNullExceptionMetadataName,
+                    context.CancellationToken,
+                    out objectCreation
+                )
             ) || objectCreation!.ArgumentList is null
         )
         {

--- a/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullOrEmptyAnalyzerTests.cs
+++ b/tests/NetEvolve.Arguments.Analyser.Tests.Unit/ThrowIfNullOrEmptyAnalyzerTests.cs
@@ -93,8 +93,10 @@ public sealed class ThrowIfNullOrEmptyAnalyzerTests
     }
 
     [Test]
-    public async Task Analyze_WhenThrowingArgumentNullException_DoesNotReportDiagnostic()
+    public async Task Analyze_WhenIsNullOrEmptyCheckThrowsArgumentNullException_ReportsDiagnostic()
     {
+        // Throwing ArgumentNullException for an IsNullOrEmpty/IsNullOrWhiteSpace check is itself a bug for the
+        // whitespace-only/empty-but-non-null case; the same throw-helper fix corrects the wrong exception type too.
         const string source = """
             using System;
 
@@ -109,7 +111,64 @@ public sealed class ThrowIfNullOrEmptyAnalyzerTests
 
         var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullOrEmptyAnalyzer(), source);
 
-        _ = await Assert.That(diagnostics).IsEmpty();
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+        _ = await Assert.That(diagnostics[0].Id).IsEqualTo("NEA0002");
+    }
+
+    [Test]
+    public async Task Analyze_WhenIsNullOrWhiteSpaceCheckThrowsArgumentNullException_ReportsDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    if (string.IsNullOrWhiteSpace(argument)) throw new ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var diagnostics = await AnalyzerVerifier.GetDiagnosticsAsync(new ThrowIfNullOrEmptyAnalyzer(), source);
+
+        _ = await Assert.That(diagnostics).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CodeFix_WhenAppliedToIsNullOrWhiteSpaceThrowingArgumentNullException_ReplacesWithThrowIfNullOrWhiteSpaceCall()
+    {
+        const string source = """
+            using System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    if (string.IsNullOrWhiteSpace(argument)) throw new ArgumentNullException(nameof(argument));
+                }
+            }
+            """;
+
+        var fixedSource = await AnalyzerVerifier.ApplyFixAsync(
+            new ThrowIfNullOrEmptyAnalyzer(),
+            new ThrowIfNullOrEmptyCodeFixProvider(),
+            source
+        );
+
+        const string expected = """
+            using System;
+
+            class C
+            {
+                void M(string? argument)
+                {
+                    ArgumentException.ThrowIfNullOrWhiteSpace(argument);
+                }
+            }
+            """;
+
+        _ = await Assert.That(fixedSource).IsEqualTo(expected);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- NEA0002 (`ThrowIfNullOrEmptyAnalyzer`) now also matches `string.IsNullOrEmpty`/`IsNullOrWhiteSpace` checks that throw `ArgumentNullException`, not just `ArgumentException`.
- Throwing `ArgumentNullException` for the empty/whitespace-only case is itself a bug (the argument isn't null); the same throw-helper fix corrects it.
- Updated docs and descriptor description; added/renamed tests covering the new shape and its code fix.

## Test plan
- [x] `dotnet test tests/NetEvolve.Arguments.Analyser.Tests.Unit` — 222 passed